### PR TITLE
cli: prep @integrityframework/cli@1.3.0 for npm publish

### DIFF
--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for the acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend, and
+      hold each Contributor harmless for any liability incurred by, or
+      claims asserted against, such Contributor by reason of your accepting
+      any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Startvest LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,37 +1,25 @@
-# integrity-framework
+# @integrityframework/cli
 
-The CLI for the [Integrity Framework](https://theintegrityframework.org/).
+The CLI for [The Integrity Framework](https://theintegrityframework.org/).
 
 Two surfaces:
 
-1. Run the Integrity Framework v1.0 assertion suite against any repo. Deterministic runner, no LLM, no network.
+1. Run the Integrity Framework v1.0 assertion suite against any repo. Deterministic runner, no LLM, no network during checks.
 2. Browse and submit listings to the [Integrity Framework Directory](https://theintegrityframework.org/).
 
-Pure ESM JavaScript, zero dependencies. Requires Node 20+.
+Pure ESM JavaScript, zero runtime dependencies. Requires Node 20+.
 
 ## Install
 
-Clone the directory repo and link the binary. Three lines:
-
 ```bash
-git clone https://github.com/Startvest-LLC/theintegrityframework.git
-cd theintegrityframework/cli
-chmod +x bin/integrity.mjs
+npm install -g @integrityframework/cli
 ```
 
-Then either run by full path (`./bin/integrity.mjs directory list`) or symlink it onto your PATH:
+Or use without install:
 
 ```bash
-# Unix
-ln -s "$(pwd)/bin/integrity.mjs" /usr/local/bin/integrity
-
-# Windows (PowerShell, run as admin once)
-New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\bin\integrity.mjs" -Target "$(Resolve-Path bin\integrity.mjs)"
+npx @integrityframework/cli check .
 ```
-
-Update with `git pull`. Each release lives at a tagged commit (`cli-v1.2.0`, etc.) you can `git checkout` into for a pinned version.
-
-Why no `npm install -g`: npm's first-publish bootstrap (org creation, 2FA-write, token type confusion) was more friction than the CLI is worth. The directory repo is public; cloning it IS the install. Future versions ship via tag — no package-registry dependency.
 
 ## Usage
 
@@ -42,15 +30,32 @@ integrity rules                  # print the v1.0 base manifest as JSON
 integrity directory list         # browse listings on theintegrityframework.org
 integrity directory show <slug>  # full detail for one listing
 integrity directory validate <file>  # check a listing JSON against the schema
-integrity directory submit <file>    # validate then surface the submission paths
+integrity directory submit <file>    # validate then surface submission paths
 integrity --version
 ```
 
+## What the runner checks
+
+The base manifest (`manifests/base-v1.json`) ships universal Layer-2 assertions from [Integrity Framework v1.0](https://theintegrityframework.org/framework/v1):
+
+- `HIGH-SV-INTEGRITY-MD` — INTEGRITY.md exists at repo root
+- `CRIT-SV-NO-SILENT-PASS` — verification failures must not silently default to a positive state
+- `HIGH-SV-METHODOLOGY-VERSIONED` — public methodology pages must carry Version + Changelog
+- `HIGH-SV-EVIDENCE-RETENTION` — customer offboarding must not delete audit/evidence/consent records
+- `CRIT-SV-NO-PRE-POPULATED-ATTESTATION` — attestation outputs must reference customer-submitted markers (the Delve-lesson rule)
+- `INFO-SV-TRUST-PRINCIPLES-LINK` — public marketing should link to trust principles
+
+Per-product manifests at `audits/rules/*.json` extend this set with product-specific checks. Rule IDs are stable: a product can re-use a base id to specialize a check (e.g. tighten the globs) while preserving framework lineage.
+
 ## Directory subcommand
 
-Reads `https://theintegrityframework.org/api/listings.json` for `list` and `show`. Writes nothing — `submit` validates the file locally and prints the two submission paths (GitHub PR or email to `integrity@startvest.ai`).
+Reads `https://theintegrityframework.org/api/listings.json` for `list` and `show`. Writes nothing — `submit` validates the file locally and prints submission paths (GitHub PR or email to `integrity@startvest.ai`).
 
-The validation schema mirrors the directory's zod schema in `../src/lib/listings.ts`. When the schema changes, both sides are updated in the same commit. That's why this CLI lives in the directory's repo.
+The validation schema mirrors the directory's zod schema in the directory site's source. When the schema changes, both sides ship in the same release. That's why this CLI lives in the directory's repo.
+
+## Source
+
+The CLI lives in the [Integrity Framework Directory repo](https://github.com/Startvest-LLC/theintegrityframework/tree/master/cli). The directory and the CLI are co-located so the listing schema and the validator stay in sync.
 
 ## License
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "integrity-framework",
-  "version": "1.2.0",
-  "private": true,
-  "description": "CLI for the Integrity Framework. Run the v1.0 assertion suite, and browse / submit listings to the Integrity Framework Directory.",
+  "name": "@integrityframework/cli",
+  "version": "1.3.0",
+  "description": "CLI for The Integrity Framework. Run the v1.0 assertion suite against any repo, browse and submit listings to the Integrity Framework Directory. Pure ESM, zero runtime dependencies.",
   "type": "module",
   "bin": {
     "integrity": "./bin/integrity.mjs"
@@ -10,10 +9,33 @@
   "engines": {
     "node": ">=20"
   },
+  "files": [
+    "bin/",
+    "src/",
+    "manifests/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
-    "test": "node test/runner.test.mjs"
+    "test": "node test/runner.test.mjs",
+    "prepublishOnly": "npm test"
   },
+  "keywords": [
+    "integrity",
+    "integrity-framework",
+    "compliance",
+    "ai-trust",
+    "agentic",
+    "framework",
+    "audit",
+    "directory",
+    "ci",
+    "linter",
+    "trust-signal",
+    "soc2-alternative"
+  ],
   "license": "Apache-2.0",
+  "author": "Startvest LLC <integrity@startvest.ai> (https://startvest.ai)",
   "homepage": "https://theintegrityframework.org",
   "repository": {
     "type": "git",
@@ -22,5 +44,9 @@
   },
   "bugs": {
     "url": "https://github.com/Startvest-LLC/theintegrityframework/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary

Reverses the prior "git clone is the install" stance and prepares the integrity CLI for npm publish under the scoped name `@integrityframework/cli`.

The CLI's positioning shifts under the v1 plan: TIF is a developer tool first and a directory second, distributed via the channel devs already use (npm). The Snyk / Semgrep / ESLint pattern — free CLI on npm → conformance density → directory growth — needs frictionless install. Git-clone bootstrapping was the wrong shape for that.

## Changes

- **`cli/package.json`** — name flipped to `@integrityframework/cli`, version 1.2.0 → 1.3.0 (first npm-published release), `private: true` removed. Added: `publishConfig` (access=public, npmjs registry), `files` allowlist (bin/, src/, manifests/, README.md, LICENSE), `prepublishOnly` script running tests, keywords for discoverability, `author` field.
- **`cli/LICENSE`** — Apache-2.0 standard text. Required for npm to render the license correctly. Same license as the package.json declaration.
- **`cli/README.md`** — rewritten. `npm install -g` and `npx` instructions primary. Added a "What the runner checks" section with the base manifest rules.

## Verification

- [x] `npm test` clean (4 tests pass)
- [x] `npm pack --dry-run` → 18.6 kB tarball, 11 files (bin/, src/, manifests/, README, LICENSE only — no test files, no `.gitignore`)
- [x] `npm publish --dry-run` clean — would publish to `registry.npmjs.org` with tag `latest` and public access
- [x] Name available on npm: both `@integrityframework/cli` and `integrity-framework` return 404 on the registry. Going with scoped per the v1 plan; rename in `package.json` before publish if preferred.

## Before actual `npm publish`

1. **One-time npm org bootstrap.** `@integrityframework` org needs to exist on npmjs.com. Create at <https://www.npmjs.com/org/create>. Set up automation token + 2FA-write per npm's standard flow.
2. **Pick the publisher account.** Org-scoped publish typically uses an org member account, not personal. Decide which Startvest npm account owns this.
3. **Run publish.**
   ```bash
   cd cli
   npm publish
   ```
4. **Verify** at <https://www.npmjs.com/package/@integrityframework/cli>.

## Not in this PR (follow-up after actual publish)

- Update `public/llms.txt`, `public/llms-full.txt` to advertise `npm install -g @integrityframework/cli`.
- Update or replace `public/install.sh` / `public/install.ps1` (currently git-clone-based).
- Add a `/cli` page on the directory site surfacing the npm package and the upcoming GitHub Action.
- GitHub Actions automation for tagged-release publishing.

## Test plan

- [x] `npm test` passes
- [x] `npm pack --dry-run` produces the right file set
- [x] `npm publish --dry-run` validates clean
- [ ] Post-merge: actual `npm publish` from npm-logged-in shell
- [ ] Post-publish: `npx @integrityframework/cli check .` works in a fresh repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)