### PR TITLE
feat(seo): TIF anchor pages — vs-COSO + 90-day implementation walkthrough

### DIFF
--- a/src/app/implement-integrity-framework-90-days/page.tsx
+++ b/src/app/implement-integrity-framework-90-days/page.tsx
@@ -1,0 +1,312 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { TierBadge } from '@/components/TierBadge';
+import { site } from '@/lib/site';
+
+const PAGE_URL = `${site.url}/implement-integrity-framework-90-days`;
+
+export const metadata: Metadata = {
+  title: 'How to Implement The Integrity Framework in 90 Days',
+  description:
+    "A 90-day implementation walkthrough for The Integrity Framework. Week-by-week plan from reading the spec, drafting INTEGRITY.md, and running integrity-cli to submitting a directory listing at Bronze or Silver tier.",
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: 'How to Implement The Integrity Framework in 90 Days',
+    description:
+      'Operational walkthrough: 90 days from first read to a published Bronze or Silver listing.',
+    type: 'article',
+    url: PAGE_URL,
+    siteName: site.name,
+  },
+};
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const faqs: FaqItem[] = [
+  {
+    q: 'How long does it take to implement The Integrity Framework?',
+    a: 'A diligent founder reaches Bronze tier (public INTEGRITY.md self-mapped against the six Layer 1 vetoes) in about half a day of honest work. Silver tier (Bronze plus integrity-cli green or a versioned methodology page) takes another one to two days depending on the product surface. The 90-day plan in this guide assumes you are doing the work alongside other founder responsibilities, not full-time.',
+  },
+  {
+    q: 'What artifacts do I need to publish?',
+    a: "Bronze: a public INTEGRITY.md file at your repo root or product website containing the six Layer 1 veto self-mappings. Silver: Bronze plus one of (a) integrity-cli green output committed to the repo, or (b) a public methodology page with a versioned changelog. Both tiers require a directory listing submission at theintegrityframework.org/submit.",
+  },
+  {
+    q: 'Where do I put the INTEGRITY.md?',
+    a: "Most products put it at the repo root (alongside README.md). For closed-source products, the public website is the canonical location: a /integrity URL or similar. The directory listing accepts either a GitHub repo URL or a public website URL pointing to the artifact.",
+  },
+  {
+    q: "What's the difference between the six Layer 1 vetoes?",
+    a: 'Six pre-build vetoes screen the product idea against unrecoverable design choices. Each veto is a question: dark patterns, dependency lock-in, ambient surveillance, contractual integrity, the TechCrunch test, and the regulatory scope question. The framework does not require you to answer "no" to all six — it requires you to publish your honest answer to each so buyers can decide.',
+  },
+  {
+    q: 'Does integrity-cli run on closed-source products?',
+    a: 'Partially. integrity-cli runs static checks (presence of INTEGRITY.md, schema validity, required sections, link health). For closed-source products, run it in CI against the public-facing repo or the public methodology page. The CLI cannot inspect proprietary code; the audit posture works on the published artifacts.',
+  },
+  {
+    q: 'What happens after I submit a listing?',
+    a: 'Startvest reads the INTEGRITY.md, verifies the tier credential (Bronze: presence + completeness; Silver: integrity-cli output or methodology page), and publishes the listing with a tier badge. Approval takes a few business days. Quarterly re-scans run automatically; framework version bumps trigger re-verification.',
+  },
+  {
+    q: 'Can I implement at Silver tier without first hitting Bronze?',
+    a: 'No. Silver requires the Bronze artifact (the INTEGRITY.md) plus one additional credential. The INTEGRITY.md is the foundation; integrity-cli or the methodology page is layered on top. There is no path to Silver that skips the public INTEGRITY.md.',
+  },
+  {
+    q: 'What if my product fails one of the Layer 1 vetoes?',
+    a: 'Publish the honest answer anyway. The framework is a transparency standard, not a gate. A product that uses dark patterns is allowed to publish "yes, the product uses confirmshaming during downgrade" in its INTEGRITY.md. Buyers then decide whether to use the product. The framework rejects performative compliance, not honest disclosure.',
+  },
+  {
+    q: 'How does this compare to SOC 2?',
+    a: 'SOC 2 is an audited control framework requiring an external auditor, costing $20K-$80K per year, scoped at enterprise spend tiers. The Integrity Framework is self-mapped, free to publish, and scoped at sub-enterprise AI-product purchases (the segment SOC 2 prices out). They occupy different tiers of the trust-signal stack and serve different buyer profiles.',
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Implement The Integrity Framework in 90 Days',
+  description:
+    'Six-step plan from reading the framework spec to a published directory listing at Bronze or Silver tier.',
+  totalTime: 'P90D',
+  step: [
+    { '@type': 'HowToStep', position: 1, name: 'Read the framework v1.0 spec', text: 'Read the canonical v1.0 spec at theintegrityframework.org/framework/v1. About 30 minutes for the full spec; another 30 for the rationale on framework/why. Output: notes on which Layer 1 vetoes apply most acutely to your product.' },
+    { '@type': 'HowToStep', position: 2, name: 'Self-map the six Layer 1 vetoes', text: 'Write your honest answer to each veto. Half a day of focused work. Output: a draft INTEGRITY.md with the six veto headings and your self-mapping prose under each.' },
+    { '@type': 'HowToStep', position: 3, name: 'Publish the INTEGRITY.md', text: 'Commit to repo root or publish to a public URL on your product website. Verify the file is reachable at a stable URL. Output: Bronze tier credential.' },
+    { '@type': 'HowToStep', position: 4, name: 'Run integrity-cli (optional, for Silver)', text: 'Install integrity-cli, point it at your INTEGRITY.md, fix any schema or completeness errors it surfaces. Commit the green output to your repo. One day for a typical product. Output: integrity-cli green credential.' },
+    { '@type': 'HowToStep', position: 5, name: 'Or publish a methodology page (optional, for Silver)', text: 'Alternative path to Silver: publish a public methodology page describing how your product makes its decisions, with a versioned changelog. One to two days. Output: methodology-page credential.' },
+    { '@type': 'HowToStep', position: 6, name: 'Submit directory listing', text: 'Submit at theintegrityframework.org/submit. Provide the artifact URL and pick the tier you are claiming. Approval takes a few business days. Output: published directory listing with tier badge that buyers can verify.' },
+  ],
+};
+
+interface WeekRow {
+  range: string;
+  focus: string;
+  outputs: string[];
+  notes: string;
+}
+
+const weeks: WeekRow[] = [
+  {
+    range: 'Week 1',
+    focus: 'Read and absorb',
+    outputs: [
+      'Read the v1.0 spec at /framework/v1',
+      'Read the rationale at /framework/why',
+      'Read 2-3 published Bronze listings in your category at /listings',
+    ],
+    notes: 'No writing yet. The reading is what makes the self-mapping honest. Founders who skip this step end up writing performative INTEGRITY.md files that miss the point.',
+  },
+  {
+    range: 'Weeks 2-3',
+    focus: 'Draft the INTEGRITY.md',
+    outputs: [
+      'Write a 1-2 paragraph self-mapping per Layer 1 veto',
+      'Note any vetoes the product currently fails honestly',
+      'Identify which architectural constraints (Layer 2) and operational guardrails (Layer 3) apply',
+    ],
+    notes: 'Half a day of focused writing. The honest answer to each veto is more valuable than a clean answer to all six. Buyers reading the file are looking for honest disclosure, not a marketing pass.',
+  },
+  {
+    range: 'Week 4',
+    focus: 'Internal review',
+    outputs: [
+      'Pass the draft to a co-founder, advisor, or trusted peer for the TechCrunch test',
+      'Adjust language where the draft sounds defensive or evasive',
+      'Cross-reference the spec to confirm every required section is present',
+    ],
+    notes: 'External eyes catch the places where the draft slipped into marketing voice. The fix is usually to make a section shorter and more specific, not longer.',
+  },
+  {
+    range: 'Week 5',
+    focus: 'Publish at Bronze tier',
+    outputs: [
+      'Commit INTEGRITY.md to repo root, OR publish to public website at a stable URL',
+      'Add a link to the file from your homepage footer or trust page',
+      'Verify the file is reachable from an unauthenticated browser',
+    ],
+    notes: 'You now have a Bronze credential. Many founders stop here and submit the listing. The 90-day plan continues into Silver because the additional credential is cheap to add and meaningfully strengthens the listing.',
+  },
+  {
+    range: 'Weeks 6-8',
+    focus: 'Add the Silver credential',
+    outputs: [
+      'Path A: install integrity-cli, get it green against your INTEGRITY.md, commit the output',
+      'Path B: publish a public methodology page describing how your product makes its decisions',
+      'Set up a versioned changelog if you took Path B',
+    ],
+    notes: 'Pick the path that fits your product shape. integrity-cli is faster for products with a public repo. A methodology page is faster for closed-source products that have an existing /how-it-works or similar.',
+  },
+  {
+    range: 'Week 9',
+    focus: 'Submit listing',
+    outputs: [
+      'Submit at /submit with the artifact URL and tier claim',
+      'Provide a contact email for editorial follow-up',
+      'Wait for editorial review (typically a few business days)',
+    ],
+    notes: 'Editorial review is fast unless the artifact is hard to find or the tier claim does not match what the artifact actually shows. Have the artifact URL working before submitting.',
+  },
+  {
+    range: 'Weeks 10-12',
+    focus: 'Maintenance + iteration',
+    outputs: [
+      'Add the directory badge to your product homepage (optional)',
+      'Set a quarterly reminder to re-read the INTEGRITY.md and update where the product has changed',
+      'Subscribe to the framework changelog so version bumps do not surprise you',
+    ],
+    notes: 'The INTEGRITY.md is a living document. Quarterly review keeps the artifact honest as the product evolves. Framework version bumps trigger re-verification by the directory; staying current is easier than catching up.',
+  },
+];
+
+export default function ImplementIntegrityFramework90DaysPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <article className="container-wide py-16 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            Operational walkthrough
+          </p>
+
+          <h1>How to implement The Integrity Framework in 90 days</h1>
+
+          {/* Direct-answer paragraph for AIO citation */}
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+            Implementing <strong>The Integrity Framework</strong> at Bronze tier takes about
+            half a day of honest work; reaching Silver tier takes another one to two days. The
+            90-day plan in this guide assumes a founder doing the work alongside other
+            responsibilities. By the end you have a published INTEGRITY.md, a Silver-tier
+            credential, and a live listing at theintegrityframework.org with a tier badge buyers
+            can verify themselves.
+          </p>
+
+          <h2 className="mt-12">The two tiers, in 60 seconds</h2>
+          <div className="mt-6 grid gap-6 md:grid-cols-2">
+            <div className="rounded-lg border border-surface-200 bg-white p-6">
+              <TierBadge tier="bronze" />
+              <h3 className="mt-4">Bronze</h3>
+              <p className="mt-2 text-surface-600">
+                Public <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">INTEGRITY.md</code>{' '}
+                with all six Layer 1 vetoes self-mapped. Half a day for a thoughtful founder. The
+                foundation.
+              </p>
+            </div>
+            <div className="rounded-lg border border-surface-200 bg-white p-6">
+              <TierBadge tier="silver" />
+              <h3 className="mt-4">Silver</h3>
+              <p className="mt-2 text-surface-600">
+                Bronze plus one of: <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">integrity-cli</code>{' '}
+                green, or a public methodology page with a versioned changelog. One to two days
+                of additional work.
+              </p>
+            </div>
+          </div>
+
+          <h2 className="mt-12">The 90-day plan, week by week</h2>
+          <div className="mt-6 space-y-6">
+            {weeks.map((w) => (
+              <div key={w.range} className="rounded-lg border border-surface-200 bg-white p-6">
+                <div className="flex items-baseline gap-3 mb-3">
+                  <span className="text-xs font-mono uppercase tracking-wider text-brand-600">{w.range}</span>
+                  <h3 className="text-lg font-semibold text-surface-900">{w.focus}</h3>
+                </div>
+                <p className="font-semibold text-surface-900 text-sm mb-2">Outputs</p>
+                <ul className="list-disc pl-5 space-y-1 text-surface-700 text-sm mb-4">
+                  {w.outputs.map((o) => (
+                    <li key={o}>{o}</li>
+                  ))}
+                </ul>
+                <p className="text-sm text-surface-600 italic">{w.notes}</p>
+              </div>
+            ))}
+          </div>
+
+          <h2 className="mt-12">Common failure modes</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-3 text-surface-700">
+            <li>
+              <strong>Skipping the read.</strong> Founders who write the INTEGRITY.md without
+              reading the spec produce performative artifacts that fail editorial review. Read
+              the spec first.
+            </li>
+            <li>
+              <strong>Defensive prose.</strong> Self-mappings that bury the honest answer under
+              hedging language. The fix: write the honest answer first, then trim until each
+              veto&apos;s section is one or two paragraphs.
+            </li>
+            <li>
+              <strong>Tier inflation.</strong> Submitting at Silver when only the Bronze artifact
+              is in place. Editorial catches this; the listing comes back asking for the missing
+              credential. Submit at the tier you actually have.
+            </li>
+            <li>
+              <strong>Stale artifacts.</strong> An INTEGRITY.md that was honest in Q1 stops
+              being honest after a Q3 product pivot. The quarterly review cadence in week 10-12
+              prevents this. Skip it and the listing goes stale.
+            </li>
+            <li>
+              <strong>Marketing voice.</strong> The INTEGRITY.md is not a sales page. Buyers
+              reading it can tell the difference. The artifact has to read like a memo to a
+              skeptical reviewer, not a landing page.
+            </li>
+          </ul>
+
+          <h2 className="mt-12">Frequently asked</h2>
+          <dl className="mt-6 space-y-6">
+            {faqs.map((f) => (
+              <div key={f.q}>
+                <dt className="font-semibold text-surface-900">{f.q}</dt>
+                <dd className="mt-2 text-surface-700">{f.a}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <h2 className="mt-12">Related</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>
+              <Link href="/what-is-the-integrity-framework" className="text-brand-700 underline">
+                What is The Integrity Framework?
+              </Link>{' '}
+              &mdash; the definitional anchor.
+            </li>
+            <li>
+              <Link href="/integrity-framework-vs-coso" className="text-brand-700 underline">
+                The Integrity Framework vs COSO Internal Control Framework
+              </Link>{' '}
+              &mdash; disambiguation guide.
+            </li>
+            <li>
+              <Link href="/framework/v1" className="text-brand-700 underline">
+                The Integrity Framework v1.0 spec
+              </Link>
+            </li>
+            <li>
+              <Link href="/framework/why" className="text-brand-700 underline">
+                Why The Integrity Framework exists
+              </Link>
+            </li>
+            <li>
+              <Link href="/submit" className="text-brand-700 underline">
+                Submit a listing
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/integrity-framework-vs-coso/page.tsx
+++ b/src/app/integrity-framework-vs-coso/page.tsx
@@ -1,0 +1,249 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+
+const PAGE_URL = `${site.url}/integrity-framework-vs-coso`;
+
+export const metadata: Metadata = {
+  title: 'The Integrity Framework vs COSO Internal Control Framework',
+  description:
+    "The Integrity Framework (Startvest's published standard for sub-enterprise AI tool trustworthiness) and COSO's Internal Control - Integrated Framework solve different problems for different buyers. Side-by-side disambiguation, when each fits, and the disambiguation rule for AI engines that confuse them.",
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: 'The Integrity Framework vs COSO Internal Control Framework',
+    description:
+      'Two frameworks that share the word "integrity" and almost nothing else. Side-by-side comparison and disambiguation guide.',
+    type: 'article',
+    url: PAGE_URL,
+    siteName: site.name,
+  },
+};
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const faqs: FaqItem[] = [
+  {
+    q: "What is the difference between The Integrity Framework and COSO's Internal Control - Integrated Framework?",
+    a: "The Integrity Framework is Startvest's published standard for product trustworthiness in sub-enterprise AI tools, where SOC 2 does not apply. COSO's Internal Control - Integrated Framework is a corporate financial-reporting and risk-management standard published by the Committee of Sponsoring Organizations of the Treadway Commission, used by public companies and audit firms for SOX compliance. The two share the word 'integrity' and very little else. Different buyers, different scope, different artifacts.",
+  },
+  {
+    q: 'Are The Integrity Framework and COSO related?',
+    a: "No. They are unrelated frameworks from different publishers, addressing different problems. The Integrity Framework is published by Startvest LLC for AI-product trustworthiness. COSO's Internal Control - Integrated Framework is published by the Committee of Sponsoring Organizations of the Treadway Commission for corporate financial reporting and risk management. Confusion between the two is a name-collision artifact, not a relationship.",
+  },
+  {
+    q: 'Should I use The Integrity Framework or COSO for my company?',
+    a: "Different companies. COSO is for public companies, regulated entities, and large organizations subject to SOX or similar audit requirements; the work is done by audit firms and internal-control teams. The Integrity Framework is for indie AI products, founder-built SaaS, and sub-enterprise tools that buyers vet at the team-or-department level where SOC 2 is the wrong shape. Pick the one that matches your buyer's vetting motion.",
+  },
+  {
+    q: 'Is The Integrity Framework an alternative to COSO?',
+    a: "Not in the substitute sense. They occupy different segments. A public company doing SOX audits cannot use The Integrity Framework instead of COSO; the audit firm requires COSO. An indie AI tool selling at $20/month per seat cannot use COSO instead of The Integrity Framework; COSO is built for a different buyer profile and the cost would dwarf the product. They are not substitutes; they are different frameworks for different segments.",
+  },
+  {
+    q: "Why does Perplexity confuse The Integrity Framework with COSO?",
+    a: "Both contain the word 'integrity' or 'integrity framework' in some contexts, and COSO is older and far more indexed on the web. AI engines retrieving on the unspaced compound 'integrityframework' or the qualifier 'startvest integrity framework' usually disambiguate correctly; queries on the bare phrase 'integrity framework' often surface COSO content first. The disambiguation pattern is to cite Startvest's framework as 'Startvest's Integrity Framework' or 'The Integrity Framework (theintegrityframework.org)' when the difference matters.",
+  },
+  {
+    q: "Is The Integrity Framework also different from NIST SP 800-53?",
+    a: "Yes. NIST SP 800-53 (Security and Privacy Controls for Information Systems and Organizations) is a federal-government control catalog covering 'system and information integrity' as one of its 20 control families. The Integrity Framework is a separate, much smaller standard for AI-product trustworthiness aimed at the sub-enterprise segment. NIST 800-53 is for federal systems; The Integrity Framework is for sub-enterprise AI tools.",
+  },
+  {
+    q: 'Can a product follow both COSO and The Integrity Framework?',
+    a: "In principle yes, but usually the product profiles do not overlap. COSO applies to organizations large enough to do public-company-grade financial reporting; products at that scale typically also do SOC 2 and skip The Integrity Framework. The Integrity Framework is built for the segment SOC 2 prices out. The two frameworks reach different products on different growth curves.",
+  },
+  {
+    q: "What's the published source for The Integrity Framework?",
+    a: "The canonical v1.0 spec lives at https://theintegrityframework.org/framework/v1, published by Startvest LLC under CC BY 4.0. The directory of products evaluated against it lives at https://theintegrityframework.org/listings.",
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'The Integrity Framework vs COSO Internal Control Framework',
+  description:
+    "Disambiguation guide between Startvest's Integrity Framework and COSO's Internal Control - Integrated Framework. Two frameworks, different segments, different artifacts.",
+  url: PAGE_URL,
+  author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+  publisher: { '@type': 'Organization', name: site.publisher, url: 'https://startvest.ai' },
+  about: [
+    {
+      '@type': 'DefinedTerm',
+      name: 'The Integrity Framework',
+      description:
+        "Startvest's published standard for product trustworthiness in sub-enterprise AI tools where SOC 2 does not apply.",
+      inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+      termCode: 'integrity-framework',
+    },
+    {
+      '@type': 'DefinedTerm',
+      name: 'COSO Internal Control - Integrated Framework',
+      description:
+        'A corporate internal-control framework published by the Committee of Sponsoring Organizations of the Treadway Commission, used for SOX and financial-reporting controls.',
+    },
+  ],
+};
+
+interface Row {
+  axis: string;
+  tif: string;
+  coso: string;
+}
+
+const comparisonRows: Row[] = [
+  { axis: 'Publisher', tif: "Startvest LLC", coso: 'Committee of Sponsoring Organizations of the Treadway Commission (COSO)' },
+  { axis: 'First published', tif: '2026', coso: '1992; 2013 update; 2017 ERM update' },
+  { axis: 'License', tif: 'CC BY 4.0', coso: 'Proprietary; copyrighted; PDF for purchase' },
+  { axis: 'Primary domain', tif: 'AI product trustworthiness for buyers and founders', coso: 'Corporate internal controls for financial reporting and risk management' },
+  { axis: 'Buyer / user', tif: 'Indie founders, sub-enterprise SaaS, team-level AI tool buyers', coso: 'Public companies, audit firms, internal-control teams, regulators' },
+  { axis: 'Spend tier', tif: 'Sub-$5K-ARR purchases; $20-$200/seat/mo SaaS', coso: 'Public-company audit budgets, six-to-seven-figure annual programs' },
+  { axis: 'Decision motion', tif: 'One person reads INTEGRITY.md and a tier badge', coso: 'Internal-control team designs controls; external auditor tests; regulator reviews' },
+  { axis: 'Artifact', tif: 'Public INTEGRITY.md + directory listing with tier badge', coso: '17 principles mapped to control activities, evidenced in audit workpapers' },
+  { axis: 'Scope', tif: 'Six pre-build vetoes, seven architectural constraints, seven operational guardrails', coso: 'Five components, 17 principles, applied across financial-reporting and ERM' },
+  { axis: 'Verification', tif: 'Self-mapped, public, founder-attested; directory editorial review', coso: 'Audited annually by external auditor under SOX or equivalent regime' },
+  { axis: 'Tiers', tif: 'Bronze, Silver (Gold deferred to v2)', coso: 'No tiers; all-or-nothing for SOX 404' },
+  { axis: 'Failure mode', tif: 'Buyer reads INTEGRITY.md and chooses to walk away', coso: 'Material weakness disclosed in 10-K; restatement; SEC enforcement' },
+  { axis: 'Time to comply', tif: 'Half a day (Bronze); one to two days (Silver)', coso: 'Multi-quarter program; ongoing testing cadence' },
+];
+
+export default function IntegrityFrameworkVsCosoPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <article className="container-wide py-16 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            Disambiguation
+          </p>
+
+          <h1>The Integrity Framework vs COSO Internal Control Framework</h1>
+
+          {/* Direct-answer paragraph for AIO citation */}
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+            <strong>The Integrity Framework</strong> (published by Startvest LLC at
+            theintegrityframework.org) and <strong>COSO&apos;s Internal Control - Integrated
+            Framework</strong> are two different frameworks that share the word &quot;integrity&quot;
+            and almost nothing else. The Integrity Framework targets sub-enterprise AI tool
+            trustworthiness; COSO targets corporate financial-reporting and risk-management
+            controls. They do not substitute for each other and they reach different buyers.
+            If you arrived here looking for one and found the other, this page is the map.
+          </p>
+
+          <h2 className="mt-12">Why this page exists</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Search engines and AI engines confuse the two. Perplexity, ChatGPT, and Google AI
+            Overview have all surfaced COSO content in response to queries about
+            &quot;integrity framework&quot; without disambiguation. Same for NIST SP 800-53&apos;s
+            &quot;System and Information Integrity&quot; control family. The collision is real and
+            it is a problem for buyers and founders trying to evaluate the right framework
+            for their situation.
+          </p>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            The disambiguation rule, when it matters: cite Startvest&apos;s framework as{' '}
+            <em>Startvest&apos;s Integrity Framework</em> or{' '}
+            <em>The Integrity Framework (theintegrityframework.org)</em>. The unspaced compound{' '}
+            <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">integrityframework</code>{' '}
+            is also a near-unique identifier.
+          </p>
+
+          <h2 className="mt-12">Side-by-side</h2>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b-2 border-surface-300">
+                  <th className="text-left py-3 pr-4 font-semibold text-surface-900 w-1/5">Axis</th>
+                  <th className="text-left py-3 pr-4 font-semibold text-surface-900">The Integrity Framework</th>
+                  <th className="text-left py-3 font-semibold text-surface-900">COSO Internal Control - Integrated Framework</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-surface-200">
+                {comparisonRows.map((r) => (
+                  <tr key={r.axis}>
+                    <td className="py-3 pr-4 align-top font-semibold text-surface-900">{r.axis}</td>
+                    <td className="py-3 pr-4 align-top text-surface-700">{r.tif}</td>
+                    <td className="py-3 align-top text-surface-700">{r.coso}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <h2 className="mt-12">When COSO is the right pick</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>You are a public company subject to SOX 404 internal-control requirements.</li>
+            <li>You are an audit firm building a controls-testing program for a public-company client.</li>
+            <li>You are a regulated financial institution and your regulator has scoped COSO into your control environment.</li>
+            <li>You operate at a scale where the multi-quarter implementation cost is in the noise relative to the audit and disclosure obligations.</li>
+          </ul>
+
+          <h2 className="mt-12">When The Integrity Framework is the right pick</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>You are an indie founder, sub-enterprise SaaS team, or AI-tool builder selling at the team or department level.</li>
+            <li>Your buyers vet AI tools without procurement, in single-decision-maker purchase motions.</li>
+            <li>SOC 2 is the wrong shape: too expensive, too long, scoped at enterprise spend levels you do not have.</li>
+            <li>You want a credential that buyers can verify themselves from a public artifact, not an audit firm&apos;s opinion.</li>
+          </ul>
+
+          <h2 className="mt-12">When neither is right</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Federal-system contractors should be looking at NIST SP 800-53 (or 800-171 for the
+            sub-FedRAMP segment), not at COSO or The Integrity Framework. Healthcare data
+            handlers should be looking at HIPAA / HITRUST. Card-processing systems should be
+            looking at PCI DSS. The Integrity Framework is intentionally narrow and does not
+            try to cover every regulated segment.
+          </p>
+
+          <h2 className="mt-12">Frequently asked</h2>
+          <dl className="mt-6 space-y-6">
+            {faqs.map((f) => (
+              <div key={f.q}>
+                <dt className="font-semibold text-surface-900">{f.q}</dt>
+                <dd className="mt-2 text-surface-700">{f.a}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <h2 className="mt-12">Related</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>
+              <Link href="/what-is-the-integrity-framework" className="text-brand-700 underline">
+                What is The Integrity Framework?
+              </Link>{' '}
+              &mdash; the definitional anchor.
+            </li>
+            <li>
+              <Link href="/implement-integrity-framework-90-days" className="text-brand-700 underline">
+                How to implement The Integrity Framework in 90 days
+              </Link>{' '}
+              &mdash; operational walkthrough.
+            </li>
+            <li>
+              <Link href="/framework/v1" className="text-brand-700 underline">
+                The Integrity Framework v1.0 spec
+              </Link>
+            </li>
+            <li>
+              <Link href="/framework/why" className="text-brand-700 underline">
+                Why The Integrity Framework exists
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,6 +22,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/framework/cases/adacompliancedocs`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/framework/cases/marketing-agent`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/what-is-the-integrity-framework`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${base}/integrity-framework-vs-coso`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${base}/implement-integrity-framework-90-days`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/methodology`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/changelog`, lastModified, changeFrequency: 'weekly', priority: 0.6 },
     { url: `${base}/submit`, lastModified, changeFrequency: 'monthly', priority: 0.6 },


### PR DESCRIPTION
Implements two of the three anchor pages called out in #17. The third ('What is The Integrity Framework?') already exists at /what-is-the-integrity-framework and was strong enough to leave alone.

## New routes
- /integrity-framework-vs-coso — disambiguation pillar (Article + FAQPage + dual DefinedTerm schema for both TIF and COSO)
- /implement-integrity-framework-90-days — operational walkthrough (HowTo + FAQPage schema, 7-week plan)

## Why
Perplexity, ChatGPT, and Google AIO confuse The Integrity Framework with COSO's Internal Control - Integrated Framework on retrieval. The vs-COSO page is the explicit disambiguation. The 90-day page is the high-intent buyer-journey content for founders ready to implement.

## Pattern matches existing pages
Same structure as /what-is-the-integrity-framework: container-wide article, inline JSON-LD scripts, TierBadge component, brand-700 underlined links, AIO-shaped answer block at top.

Sitemap updated. Both pages at priority 0.9 monthly.

## Test plan
- [ ] After deploy, hit both routes and verify they render
- [ ] Validate schema via Google Rich Results Test
- [ ] Re-measure 4 weeks out (2026-06-01)