### PR TITLE
feat(seo): /spec, /implementation, /certifications — 36 new pages

### DIFF
--- a/src/app/certifications/[level]/page.tsx
+++ b/src/app/certifications/[level]/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { site } from '@/lib/site';
+import {
+  CERTIFICATIONS,
+  getAllCertificationSlugs,
+  getCertificationBySlug,
+} from '@/lib/certifications';
+
+export function generateStaticParams() {
+  return getAllCertificationSlugs().map((level) => ({ level }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ level: string }>;
+}): Promise<Metadata> {
+  const { level } = await params;
+  const cert = getCertificationBySlug(level);
+  if (!cert) return { title: 'Certification tier not found' };
+  const url = `${site.url}/certifications/${cert.slug}`;
+  return {
+    title: `${cert.title} — Integrity Framework certification`,
+    description: cert.oneLine,
+    alternates: { canonical: `/certifications/${cert.slug}` },
+    openGraph: {
+      title: `${cert.title} certification — ${site.shortName}`,
+      description: cert.oneLine,
+      url,
+      type: 'article',
+      siteName: site.name,
+    },
+  };
+}
+
+export default async function CertificationDetailPage({
+  params,
+}: {
+  params: Promise<{ level: string }>;
+}) {
+  const { level } = await params;
+  const cert = getCertificationBySlug(level);
+  if (!cert) notFound();
+
+  const url = `${site.url}/certifications/${cert.slug}`;
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${cert.title} certification — Integrity Framework`,
+    description: cert.oneLine,
+    author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+    publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+    inLanguage: 'en-US',
+    mainEntityOfPage: url,
+    url,
+    isBasedOn: `${site.url}/methodology#${cert.methodologyAnchor}`,
+  };
+
+  const isDeferred = cert.status === 'deferred';
+  const others = CERTIFICATIONS.filter((c) => c.slug !== cert.slug);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <article className="container-wide py-16 md:py-20">
+        <header className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            <Link
+              href="/certifications"
+              className="text-brand-600 no-underline hover:text-brand-700"
+            >
+              Certifications
+            </Link>{' '}
+            · {cert.title}
+          </p>
+          <h1>{cert.title} tier</h1>
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">{cert.oneLine}</p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-mono uppercase tracking-widest ${
+                isDeferred
+                  ? 'bg-bronze-50 text-bronze-700 ring-1 ring-inset ring-bronze-200'
+                  : 'bg-brand-50 text-brand-700 ring-1 ring-inset ring-brand-200'
+              }`}
+            >
+              {isDeferred ? 'Deferred · future framework version' : 'Live · accepting submissions'}
+            </span>
+            <Link
+              href={`/methodology#${cert.methodologyAnchor}`}
+              className="text-sm text-brand-700 underline hover:text-brand-800"
+            >
+              Cite from /methodology →
+            </Link>
+          </div>
+        </header>
+
+        {cert.requirements.length > 0 && (
+          <section className="mt-12 max-w-3xl">
+            <h2>Requirements</h2>
+            <ul className="mt-4 space-y-3 list-disc list-outside pl-5 text-surface-700 leading-relaxed">
+              {cert.requirements.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {cert.effort && (
+          <section className="mt-12 max-w-3xl">
+            <h2>Effort</h2>
+            <p className="mt-3 text-surface-700 leading-relaxed">{cert.effort}</p>
+          </section>
+        )}
+
+        {cert.howVerified && (
+          <section className="mt-12 max-w-3xl">
+            <h2>How it&apos;s verified</h2>
+            <p className="mt-3 text-surface-700 leading-relaxed">{cert.howVerified}</p>
+          </section>
+        )}
+
+        <section className="mt-12 max-w-3xl space-y-5 text-surface-700 leading-relaxed">
+          <h2>About this tier</h2>
+          {cert.body.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </section>
+
+        {!isDeferred && (
+          <section className="mt-12 max-w-3xl rounded-xl border border-surface-200 bg-surface-50 p-6">
+            <h2 className="text-lg">Submit a {cert.title} listing</h2>
+            <p className="mt-3 text-surface-700">
+              Listings are submitted via the{' '}
+              <Link href="/submit" className="text-brand-700 underline hover:text-brand-800">
+                /submit
+              </Link>{' '}
+              page. Free, three submission paths (form, GitHub PR, email). Review SLA: 14 calendar
+              days from submission to first response.
+            </p>
+          </section>
+        )}
+
+        <section className="mt-12 max-w-3xl">
+          <h2>Other tiers</h2>
+          <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+            {others.map((c) => (
+              <li key={c.slug}>
+                <Link
+                  href={`/certifications/${c.slug}`}
+                  className="block rounded-lg border border-surface-200 bg-white p-4 hover:border-brand-600 transition-colors no-underline"
+                >
+                  <p className="font-mono text-[11px] uppercase tracking-widest text-brand-600">
+                    {c.status === 'deferred' ? 'Deferred' : 'Live'}
+                  </p>
+                  <p className="mt-1 font-medium text-surface-900">{c.title}</p>
+                  <p className="mt-2 text-sm text-surface-700">{c.oneLine}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/certifications/page.tsx
+++ b/src/app/certifications/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+import { CERTIFICATIONS } from '@/lib/certifications';
+
+const PAGE_URL = `${site.url}/certifications`;
+
+export const metadata: Metadata = {
+  title: 'Certification tiers — The Integrity Framework',
+  description:
+    'Two live tiers (Bronze, Silver) and one deferred (Gold). Bronze: public INTEGRITY.md self-mapping the six Layer 1 vetoes. Silver: Bronze plus integrity-cli green run or versioned methodology page.',
+  alternates: { canonical: '/certifications' },
+  openGraph: {
+    title: 'Certification tiers — The Integrity Framework',
+    description:
+      'Two live tiers (Bronze, Silver) and one deferred (Gold). Each tier is a structural commitment readable by procurement reviewers.',
+    url: PAGE_URL,
+    type: 'website',
+    siteName: site.name,
+  },
+};
+
+export default function CertificationsIndexPage() {
+  return (
+    <article className="container-wide py-16 md:py-20">
+      <header className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+          Certifications
+        </p>
+        <h1>Tiers a product can carry under the framework.</h1>
+        <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+          Two live tiers (Bronze, Silver) and one deferred (Gold). Each tier corresponds to a
+          structural commitment a product can make against the framework. The full tier wording
+          lives at{' '}
+          <Link
+            href="/methodology#tiers"
+            className="text-brand-700 underline hover:text-brand-800"
+          >
+            /methodology — Tiers
+          </Link>
+          .
+        </p>
+      </header>
+
+      <section className="mt-12 max-w-3xl space-y-4">
+        {CERTIFICATIONS.map((cert) => (
+          <Link
+            key={cert.slug}
+            href={`/certifications/${cert.slug}`}
+            className="block rounded-xl border border-surface-200 bg-white p-6 hover:border-brand-600 transition-colors no-underline"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-3 mb-3">
+              <p className="font-mono text-xs uppercase tracking-widest text-brand-600">
+                {cert.title} tier
+              </p>
+              <span
+                className={`font-mono text-[10px] uppercase tracking-widest px-2 py-0.5 rounded ${
+                  cert.status === 'deferred'
+                    ? 'bg-bronze-50 text-bronze-700 ring-1 ring-inset ring-bronze-200'
+                    : 'bg-brand-50 text-brand-700 ring-1 ring-inset ring-brand-200'
+                }`}
+              >
+                {cert.status === 'deferred' ? 'Deferred' : 'Live'}
+              </span>
+            </div>
+            <h2 className="font-display text-xl md:text-2xl font-semibold text-surface-900 mb-2">
+              {cert.title}
+            </h2>
+            <p className="text-surface-700 leading-relaxed">{cert.oneLine}</p>
+            <p className="mt-3 text-sm text-brand-700">Read the {cert.title} requirements →</p>
+          </Link>
+        ))}
+      </section>
+
+      <section className="mt-12 max-w-3xl rounded-xl border border-surface-200 bg-surface-50 p-6">
+        <h2 className="text-lg">Submit a listing</h2>
+        <p className="mt-3 text-surface-700">
+          Submissions land at{' '}
+          <Link href="/submit" className="text-brand-700 underline hover:text-brand-800">
+            /submit
+          </Link>
+          . Three paths (form, GitHub PR, email). Free. 14-calendar-day review SLA.
+        </p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/implementation/[slug]/page.tsx
+++ b/src/app/implementation/[slug]/page.tsx
@@ -1,0 +1,176 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { site } from '@/lib/site';
+import {
+  IMPLEMENTATIONS,
+  getAllImplementationSlugs,
+  getImplementationBySlug,
+} from '@/lib/implementations';
+import { SPEC_TOPICS } from '@/lib/spec-topics';
+
+export function generateStaticParams() {
+  return getAllImplementationSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const impl = getImplementationBySlug(slug);
+  if (!impl) return { title: 'Implementation not found' };
+  const url = `${site.url}/implementation/${impl.slug}`;
+  return {
+    title: `${impl.title} — Integrity Framework`,
+    description: impl.oneLine,
+    alternates: { canonical: `/implementation/${impl.slug}` },
+    openGraph: {
+      title: `${impl.title} — ${site.shortName}`,
+      description: impl.oneLine,
+      url,
+      type: 'article',
+      siteName: site.name,
+    },
+  };
+}
+
+const STATUS_COPY: Record<string, { label: string; tone: 'pass' | 'warn' }> = {
+  live: { label: 'Live · public package', tone: 'pass' },
+  'pre-launch': { label: 'Pre-launch · restricted access', tone: 'warn' },
+};
+
+export default async function ImplementationDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const impl = getImplementationBySlug(slug);
+  if (!impl) notFound();
+
+  const status = STATUS_COPY[impl.status];
+  const topics = impl.coversTopics
+    .map((s) => SPEC_TOPICS.find((t) => t.slug === s))
+    .filter((t): t is NonNullable<typeof t> => Boolean(t));
+
+  const url = `${site.url}/implementation/${impl.slug}`;
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: `${impl.title} — Integrity Framework`,
+    description: impl.oneLine,
+    author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+    publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+    inLanguage: 'en-US',
+    mainEntityOfPage: url,
+    url,
+    isBasedOn: `${site.url}/framework/v1`,
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <article className="container-wide py-16 md:py-20">
+        <header className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            <Link href="/implementation" className="text-brand-600 no-underline hover:text-brand-700">
+              Implementations
+            </Link>{' '}
+            · {impl.kind === 'cli' ? 'CLI' : impl.kind === 'library' ? 'Library' : 'Integration'}
+          </p>
+          <h1>{impl.title}</h1>
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">{impl.oneLine}</p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-mono uppercase tracking-widest ${
+                status.tone === 'pass'
+                  ? 'bg-brand-50 text-brand-700 ring-1 ring-inset ring-brand-200'
+                  : 'bg-bronze-50 text-bronze-700 ring-1 ring-inset ring-bronze-200'
+              }`}
+            >
+              {status.label}
+            </span>
+            {impl.packageName && (
+              <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-mono bg-surface-100 text-surface-800 ring-1 ring-inset ring-surface-200">
+                {impl.packageName}
+              </span>
+            )}
+            {impl.repoUrl && (
+              <a
+                href={impl.repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-brand-700 underline hover:text-brand-800"
+              >
+                Repo →
+              </a>
+            )}
+          </div>
+
+          {impl.statusNote && (
+            <p className="mt-4 rounded-md border border-bronze-200 bg-bronze-50 px-4 py-3 text-sm text-bronze-800">
+              <span className="font-medium">Status note.</span> {impl.statusNote}
+            </p>
+          )}
+        </header>
+
+        <section className="mt-12 max-w-3xl">
+          <h2>Install</h2>
+          <pre className="mt-3 rounded-xl border border-surface-200 bg-surface-900 text-surface-100 p-5 font-mono text-sm leading-relaxed overflow-x-auto whitespace-pre-wrap break-words">
+            {impl.install}
+          </pre>
+        </section>
+
+        <section className="mt-12 max-w-3xl">
+          <h2>Usage</h2>
+          <div className="mt-6 space-y-8">
+            {impl.usage.map((u, i) => (
+              <div key={i}>
+                <h3 className="text-lg font-semibold text-surface-900">{u.heading}</h3>
+                <pre className="mt-3 rounded-xl border border-surface-200 bg-surface-900 text-surface-100 p-5 font-mono text-sm leading-relaxed overflow-x-auto whitespace-pre">
+                  {u.code}
+                </pre>
+                {u.note && <p className="mt-2 text-sm text-surface-600">{u.note}</p>}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-12 max-w-3xl space-y-5 text-surface-700 leading-relaxed">
+          <h2>About this implementation</h2>
+          {impl.body.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </section>
+
+        {topics.length > 0 && (
+          <section className="mt-12 max-w-3xl">
+            <h2>Spec topics this implementation covers</h2>
+            <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+              {topics.map((t) => (
+                <li key={t.slug}>
+                  <Link
+                    href={`/spec/${t.slug}`}
+                    className="block rounded-lg border border-surface-200 bg-white p-4 hover:border-brand-600 transition-colors no-underline"
+                  >
+                    <p className="font-mono text-[11px] uppercase tracking-widest text-brand-600">
+                      {t.layerLabel}
+                    </p>
+                    <p className="mt-1 font-medium text-surface-900">{t.title}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </article>
+    </>
+  );
+}

--- a/src/app/implementation/page.tsx
+++ b/src/app/implementation/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+import { IMPLEMENTATIONS } from '@/lib/implementations';
+
+const PAGE_URL = `${site.url}/implementation`;
+
+export const metadata: Metadata = {
+  title: 'Reference implementations — The Integrity Framework',
+  description:
+    'Reference implementations of the Integrity Framework: integrity-cli (Layer 2 runner), brief-core / brief-cli (brief.md spec), GitHub Actions workflow, INTEGRITY.md authoring template. Real implementations only.',
+  alternates: { canonical: '/implementation' },
+  openGraph: {
+    title: 'Reference implementations — The Integrity Framework',
+    description:
+      "Reference implementations of the Integrity Framework. Real implementations only — pages for languages or tools without a working parser are deliberately absent.",
+    url: PAGE_URL,
+    type: 'website',
+    siteName: site.name,
+  },
+};
+
+export default function ImplementationsIndexPage() {
+  return (
+    <article className="container-wide py-16 md:py-20">
+      <header className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+          Reference implementations
+        </p>
+        <h1>How the framework actually runs.</h1>
+        <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+          The Layer 2 architectural constraints are CI-enforced by reference implementations. The
+          list below covers what ships today: one live runner, one live integration, two pre-launch
+          libraries, one authoring convention. {IMPLEMENTATIONS.length} pages.
+        </p>
+        <p className="mt-3 text-base text-surface-600">
+          Drop rule from the framework spec: a language without a working parser doesn&apos;t get a
+          page. Python, Go, Rust, and other ports are absent until real implementations ship.
+        </p>
+      </header>
+
+      <section className="mt-12 max-w-3xl space-y-4">
+        {IMPLEMENTATIONS.map((impl) => (
+          <Link
+            key={impl.slug}
+            href={`/implementation/${impl.slug}`}
+            className="block rounded-xl border border-surface-200 bg-white p-6 hover:border-brand-600 transition-colors no-underline"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-3 mb-3">
+              <p className="font-mono text-xs uppercase tracking-widest text-brand-600">
+                {impl.kind === 'cli'
+                  ? 'CLI'
+                  : impl.kind === 'library'
+                    ? 'Library'
+                    : 'Integration'}
+                {' · '}
+                {impl.status === 'live' ? 'Live' : 'Pre-launch'}
+              </p>
+              {impl.packageName && (
+                <span className="font-mono text-xs text-surface-500">{impl.packageName}</span>
+              )}
+            </div>
+            <h2 className="font-display text-xl md:text-2xl font-semibold text-surface-900 mb-2">
+              {impl.title}
+            </h2>
+            <p className="text-surface-700 leading-relaxed">{impl.oneLine}</p>
+            <p className="mt-3 text-sm text-brand-700">Read the implementation guide →</p>
+          </Link>
+        ))}
+      </section>
+
+      <section className="mt-12 max-w-3xl rounded-xl border border-surface-200 bg-surface-50 p-6">
+        <h2 className="text-lg">Spec context</h2>
+        <p className="mt-3 text-surface-700">
+          Each implementation page links back to the spec topics it covers. Start at{' '}
+          <Link href="/spec" className="text-brand-700 underline hover:text-brand-800">
+            /spec
+          </Link>{' '}
+          for the topic-by-topic index, or{' '}
+          <Link href="/framework/v1" className="text-brand-700 underline hover:text-brand-800">
+            /framework/v1
+          </Link>{' '}
+          for the frozen full-spec wording.
+        </p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from 'next';
 import { getActiveListings } from '@/lib/listings';
 import { site } from '@/lib/site';
+import { SPEC_TOPICS } from '@/lib/spec-topics';
+import { IMPLEMENTATIONS } from '@/lib/implementations';
+import { CERTIFICATIONS } from '@/lib/certifications';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = site.url.replace(/\/$/, '');
@@ -23,10 +26,34 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/framework/cases/marketing-agent`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/what-is-the-integrity-framework`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/methodology`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${base}/spec`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${base}/implementation`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
+    { url: `${base}/certifications`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
     { url: `${base}/changelog`, lastModified, changeFrequency: 'weekly', priority: 0.6 },
     { url: `${base}/submit`, lastModified, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${base}/submit/form`, lastModified, changeFrequency: 'monthly', priority: 0.7 },
   ];
+
+  const specTopicRoutes: MetadataRoute.Sitemap = SPEC_TOPICS.map((t) => ({
+    url: `${base}/spec/${t.slug}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.75,
+  }));
+
+  const implementationRoutes: MetadataRoute.Sitemap = IMPLEMENTATIONS.map((i) => ({
+    url: `${base}/implementation/${i.slug}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.75,
+  }));
+
+  const certificationRoutes: MetadataRoute.Sitemap = CERTIFICATIONS.map((c) => ({
+    url: `${base}/certifications/${c.slug}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.75,
+  }));
 
   const listingRoutes: MetadataRoute.Sitemap = getActiveListings().map((l) => ({
     url: `${base}/listings/${l.slug}`,
@@ -35,5 +62,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  return [...staticRoutes, ...listingRoutes];
+  return [
+    ...staticRoutes,
+    ...specTopicRoutes,
+    ...implementationRoutes,
+    ...certificationRoutes,
+    ...listingRoutes,
+  ];
 }

--- a/src/app/spec/[topic]/page.tsx
+++ b/src/app/spec/[topic]/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { site } from '@/lib/site';
+import {
+  SPEC_TOPICS,
+  SPEC_VERSION,
+  SPEC_LAST_UPDATED,
+  getAllSpecTopicSlugs,
+  getSpecTopicBySlug,
+} from '@/lib/spec-topics';
+
+export function generateStaticParams() {
+  return getAllSpecTopicSlugs().map((topic) => ({ topic }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ topic: string }>;
+}): Promise<Metadata> {
+  const { topic } = await params;
+  const t = getSpecTopicBySlug(topic);
+  if (!t) return { title: 'Spec topic not found' };
+  const url = `${site.url}/spec/${t.slug}`;
+  return {
+    title: `${t.title} — Integrity Framework spec`,
+    description: t.oneLine,
+    alternates: { canonical: `/spec/${t.slug}` },
+    openGraph: {
+      title: `${t.title} — ${site.shortName} v${SPEC_VERSION}`,
+      description: t.oneLine,
+      url,
+      type: 'article',
+      siteName: site.name,
+      publishedTime: `${SPEC_LAST_UPDATED}T00:00:00Z`,
+      authors: ['Startvest LLC'],
+    },
+  };
+}
+
+export default async function SpecTopicPage({
+  params,
+}: {
+  params: Promise<{ topic: string }>;
+}) {
+  const { topic } = await params;
+  const t = getSpecTopicBySlug(topic);
+  if (!t) notFound();
+
+  const url = `${site.url}/spec/${t.slug}`;
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: `${t.title} — Integrity Framework spec`,
+    description: t.oneLine,
+    author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+    publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+    datePublished: `${SPEC_LAST_UPDATED}T00:00:00Z`,
+    dateModified: `${SPEC_LAST_UPDATED}T00:00:00Z`,
+    inLanguage: 'en-US',
+    mainEntityOfPage: url,
+    url,
+    isBasedOn: `${site.url}/framework/v1#${t.specAnchor}`,
+    version: SPEC_VERSION,
+    license: 'https://creativecommons.org/licenses/by/4.0/',
+  };
+
+  const related = (t.relatedTopics ?? [])
+    .map((slug) => SPEC_TOPICS.find((x) => x.slug === slug))
+    .filter((x): x is NonNullable<typeof x> => Boolean(x));
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <article className="container-wide py-16 md:py-20">
+        <header className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            <Link href="/spec" className="text-brand-600 no-underline hover:text-brand-700">
+              Spec
+            </Link>{' '}
+            · {t.layerLabel} · v{SPEC_VERSION}
+          </p>
+          <h1>{t.title}</h1>
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">{t.oneLine}</p>
+
+          <div className="mt-6 inline-flex flex-wrap items-center gap-2 font-mono text-[11px] tracking-wide text-surface-600 border border-surface-200 rounded-md px-3 py-1.5 bg-surface-50">
+            <span>
+              Spec section <b className="text-surface-900 font-medium">{t.specSection}</b>
+            </span>
+            <span className="text-surface-400">·</span>
+            <span>
+              <Link
+                href={`/framework/v1#${t.specAnchor}`}
+                className="text-surface-900 font-medium underline hover:text-brand-700"
+              >
+                cite v{SPEC_VERSION}
+              </Link>
+            </span>
+            <span className="text-surface-400">·</span>
+            <span>
+              Last updated <b className="text-surface-900 font-medium">{SPEC_LAST_UPDATED}</b>
+            </span>
+          </div>
+        </header>
+
+        <section className="mt-12 max-w-3xl grid gap-6 md:grid-cols-2">
+          <div className="rounded-xl border border-brand-200 bg-brand-50 p-5">
+            <p className="text-xs font-semibold uppercase tracking-widest text-brand-700 mb-2">
+              Pass
+            </p>
+            <p className="text-surface-800 leading-relaxed">{t.passes}</p>
+          </div>
+          <div className="rounded-xl border border-bronze-200 bg-bronze-50 p-5">
+            <p className="text-xs font-semibold uppercase tracking-widest text-bronze-800 mb-2">
+              Fail
+            </p>
+            <p className="text-surface-800 leading-relaxed">{t.fails}</p>
+          </div>
+        </section>
+
+        <section className="mt-12 max-w-3xl space-y-5 text-surface-700 leading-relaxed">
+          {t.body.map((p, i) => (
+            <p key={i}>{p}</p>
+          ))}
+        </section>
+
+        {t.relatedCases && t.relatedCases.length > 0 && (
+          <section className="mt-12 max-w-3xl">
+            <h2>Surfaced by case study</h2>
+            <p className="mt-3 text-surface-700">
+              The following published case studies surfaced or refined this topic.
+            </p>
+            <ul className="mt-4 space-y-2 list-disc list-inside text-surface-700">
+              {t.relatedCases.map((slug) => (
+                <li key={slug}>
+                  <Link
+                    href={`/framework/cases/${slug}`}
+                    className="text-brand-700 hover:text-brand-800 underline"
+                  >
+                    /framework/cases/{slug}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {related.length > 0 && (
+          <section className="mt-12 max-w-3xl">
+            <h2>Related topics</h2>
+            <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+              {related.map((r) => (
+                <li key={r.slug}>
+                  <Link
+                    href={`/spec/${r.slug}`}
+                    className="block rounded-lg border border-surface-200 bg-white p-4 hover:border-brand-600 transition-colors no-underline"
+                  >
+                    <p className="font-mono text-[11px] uppercase tracking-widest text-brand-600">
+                      {r.layerLabel}
+                    </p>
+                    <p className="mt-1 font-medium text-surface-900">{r.title}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="mt-12 max-w-3xl rounded-xl border border-surface-200 bg-surface-50 p-6">
+          <h2 className="text-lg">Cite this topic</h2>
+          <p className="mt-3 text-surface-700">
+            This topic page is an indexed reference into the v{SPEC_VERSION} spec. The frozen wording
+            lives at{' '}
+            <Link href={`/framework/v1#${t.specAnchor}`} className="text-brand-700 underline">
+              /framework/v1#{t.specAnchor}
+            </Link>
+            . Cite that URL when the wording matters.
+          </p>
+          <p className="mt-3 text-sm text-surface-500">
+            Spec license: CC BY 4.0. Originated by Startvest LLC.
+          </p>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/spec/page.tsx
+++ b/src/app/spec/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+import {
+  SPEC_TOPICS,
+  SPEC_VERSION,
+  SPEC_LAST_UPDATED,
+  getSpecTopicsByLayer,
+} from '@/lib/spec-topics';
+
+const PAGE_URL = `${site.url}/spec`;
+
+export const metadata: Metadata = {
+  title: 'Spec topics — The Integrity Framework',
+  description:
+    "Per-topic reference into the Integrity Framework v" +
+    SPEC_VERSION +
+    ' spec: five failure modes, six Layer 1 vetoes, seven Layer 2 architectural constraints, seven Layer 3 operational guardrails. Each topic cites the published spec section.',
+  alternates: { canonical: '/spec' },
+  openGraph: {
+    title: `Spec topics — ${site.shortName} v${SPEC_VERSION}`,
+    description:
+      'Per-topic reference into the Integrity Framework spec. Failure modes, vetoes, architectural constraints, operational guardrails. Each topic cites the published section.',
+    url: PAGE_URL,
+    type: 'website',
+    siteName: site.name,
+  },
+};
+
+const SECTIONS = [
+  {
+    layer: 'failure-mode' as const,
+    title: 'Failure modes',
+    intro:
+      'Five recurring failure modes the framework is reverse-engineered from. Each is named so it can be defended against by name.',
+  },
+  {
+    layer: 'layer-1' as const,
+    title: 'Layer 1 — Pre-build vetoes',
+    intro:
+      'Six questions evaluated before a product gets built or before a major scope expansion. Wrong answer kills the product, not delays it.',
+  },
+  {
+    layer: 'layer-2' as const,
+    title: 'Layer 2 — Architectural constraints',
+    intro:
+      'Seven constraints baked into every product, CI-enforced where the codebase shape allows. The reference runner is integrity-cli.',
+  },
+  {
+    layer: 'layer-3' as const,
+    title: 'Layer 3 — Operational guardrails',
+    intro:
+      'Seven business practices that prevent the model from turning sour over time.',
+  },
+];
+
+export default function SpecIndexPage() {
+  return (
+    <article className="container-wide py-16 md:py-20">
+      <header className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+          Spec topics · v{SPEC_VERSION}
+        </p>
+        <h1>The framework, indexed by topic.</h1>
+        <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+          Per-topic reference into the published v{SPEC_VERSION} spec. {SPEC_TOPICS.length} topics,
+          one page each, every page citing the exact spec section it indexes. The frozen full-spec
+          wording lives at{' '}
+          <Link href="/framework/v1" className="text-brand-700 underline hover:text-brand-800">
+            /framework/v1
+          </Link>
+          .
+        </p>
+        <p className="mt-3 text-base text-surface-600">
+          Spec last updated {SPEC_LAST_UPDATED}. Topic pages are an indexed view; they don&apos;t
+          replace the canonical spec URL.
+        </p>
+      </header>
+
+      {SECTIONS.map((section) => {
+        const topics = getSpecTopicsByLayer(section.layer);
+        return (
+          <section key={section.layer} className="mt-12 max-w-3xl">
+            <h2>{section.title}</h2>
+            <p className="mt-3 text-surface-700">{section.intro}</p>
+            <ul className="mt-6 space-y-3">
+              {topics.map((t) => (
+                <li key={t.slug}>
+                  <Link
+                    href={`/spec/${t.slug}`}
+                    className="block rounded-lg border border-surface-200 bg-white p-5 hover:border-brand-600 transition-colors no-underline"
+                  >
+                    <p className="font-mono text-[11px] uppercase tracking-widest text-brand-600">
+                      {t.specSection}
+                    </p>
+                    <p className="mt-1 font-display text-lg font-semibold text-surface-900">
+                      {t.title}
+                    </p>
+                    <p className="mt-2 text-sm text-surface-700 leading-relaxed">{t.oneLine}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+
+      <section className="mt-12 max-w-3xl rounded-xl border border-surface-200 bg-surface-50 p-6">
+        <h2 className="text-lg">Implementations and tiers</h2>
+        <p className="mt-3 text-surface-700">
+          The Layer 2 constraints are CI-enforced by reference implementations — see{' '}
+          <Link href="/implementation" className="text-brand-700 underline hover:text-brand-800">
+            /implementation
+          </Link>{' '}
+          for the languages and tools that ship a working reference parser or runner today. The
+          tiers a product can carry under the framework live at{' '}
+          <Link href="/certifications" className="text-brand-700 underline hover:text-brand-800">
+            /certifications
+          </Link>
+          .
+        </p>
+      </section>
+    </article>
+  );
+}

--- a/src/lib/certifications.ts
+++ b/src/lib/certifications.ts
@@ -1,0 +1,85 @@
+// Certification tier data. Wording is the canonical wording from the live
+// methodology page (/methodology — Tiers section). If you change wording on
+// /methodology, mirror it here. Drop rule: tier pages cite /methodology by
+// section anchor; never invent a tier the spec doesn't currently carry.
+
+export type CertStatus = 'live' | 'deferred';
+
+export interface Certification {
+  slug: 'bronze' | 'silver' | 'gold';
+  title: string;
+  status: CertStatus;
+  oneLine: string;
+  requirements: string[];
+  effort?: string;
+  howVerified?: string;
+  body: string[];
+  methodologyAnchor: string;
+}
+
+export const CERTIFICATIONS: Certification[] = [
+  {
+    slug: 'bronze',
+    title: 'Bronze',
+    status: 'live',
+    oneLine:
+      "Public INTEGRITY.md at the product's repo root or website, self-mapping all six Layer 1 vetoes.",
+    requirements: [
+      "Public INTEGRITY.md at the product's repo root or website.",
+      'All six Layer 1 vetoes self-mapped: artifact-vs-outcome, independence, verifiability, AI accountability, pricing-rigor, the TechCrunch test.',
+    ],
+    effort:
+      'Roughly half a day of honest reflection and writing for a thoughtful founder. The artifact survives the team — it is a structural commitment readable by procurement reviewers, future engineers, and the directory re-scan workflow.',
+    howVerified:
+      "At submission, the directory operator reads the listing's INTEGRITY.md. Approve, request changes, or reject within a 14-calendar-day SLA. Bronze listings are re-scanned on the same quarterly cadence as Silver, with manual re-review for closed-source listings to confirm the INTEGRITY.md has not been silently weakened.",
+    body: [
+      'Bronze is the entry tier. Every Layer 1 veto answered honestly, with PASS / PARTIAL / NOT-YET / N/A status, file-path or methodology pointers for non-trivial answers, and close dates for any partials.',
+      "The bar is lower than Silver but the rigor is real. PARTIAL or NOT-YET on a Layer 1 veto is allowed at Bronze — what's not allowed is hand-waving. A 'committed to' status with no implementation pointer fails the gate.",
+      "The directory's own INTEGRITY.md is self-rated Bronze, not Silver. A self-issued Silver from the directory operator would defeat the operator-COI disclosure pattern.",
+    ],
+    methodologyAnchor: 'tiers',
+  },
+  {
+    slug: 'silver',
+    title: 'Silver',
+    status: 'live',
+    oneLine:
+      "Bronze, plus either an integrity-cli green run against the listed public repo, or a public methodology page with Version + Changelog headings.",
+    requirements: [
+      'Bronze (all six Layer 1 vetoes self-mapped).',
+      'Plus one of: an integrity-cli green run against the listed public repo (Layer 2 architectural checks pass), OR a public methodology page with a Version heading and a Changelog heading.',
+    ],
+    effort:
+      "The integrity-cli path is the lighter lift for code-bearing products that already follow the framework — most of the work is in the underlying architecture, not the credential. The methodology-page path is the lighter lift for document-heavy or closed-source products.",
+    howVerified:
+      'For Silver claims, the directory operator runs integrity-cli against the public repo, or reads the methodology page for Version + Changelog headings. Re-scans run quarterly and on framework version bumps. Silver listings that fail re-scan are downgraded to Bronze (if the failure affects only the Silver gate) with a public note and a 30-day grace window for remediation.',
+    body: [
+      "The OR is deliberate. Code-bearing products demonstrate framework conformance via the runner; document-heavy or closed-source products demonstrate via the methodology page. Both prove framework conformance from different angles.",
+      "The methodology-page path requires Version and Changelog headings specifically. Versioned-and-changelogged is the structural defense against silent drift — a methodology that drifts silently is the failure mode the framework defends against.",
+      "Silver is the highest tier the directory currently offers. Gold is deferred to a future framework version; the directory does not retrofit a tier no operator at this segment can reach.",
+    ],
+    methodologyAnchor: 'tiers',
+  },
+  {
+    slug: 'gold',
+    title: 'Gold',
+    status: 'deferred',
+    oneLine:
+      "Deferred to a future framework version. The directory will not retrofit a tier no operator at this segment can reach.",
+    requirements: [],
+    body: [
+      "Gold is deferred. The methodology page (/methodology — Tiers) records this explicitly: 'Two tiers at v1: Bronze and Silver. Gold is deferred to a future framework version. The directory will not retrofit a tier no operator at this segment can reach.'",
+      "The deferral is structural, not lazy. A tier that no current operator can plausibly reach would either (a) sit unawarded indefinitely, becoming aspirational marketing copy, or (b) get retrofitted backwards from whichever operator pushed hardest, becoming political. Both are framework failure modes the framework specifically defends against.",
+      "When Gold lands in a future framework version, it will land with concrete requirements that at least one current operator can reach within a reasonable engagement window. Until then, the highest tier the directory offers is Silver — and that ceiling is itself a credibility commitment.",
+    ],
+    methodologyAnchor: 'tiers',
+  },
+];
+
+export function getAllCertificationSlugs(): string[] {
+  return CERTIFICATIONS.map((c) => c.slug);
+}
+
+export function getCertificationBySlug(slug: string): Certification | undefined {
+  return CERTIFICATIONS.find((c) => c.slug === slug);
+}

--- a/src/lib/implementations.ts
+++ b/src/lib/implementations.ts
@@ -1,0 +1,278 @@
+// Reference implementation data. Drop rule (from the SEO spec): "If a parser
+// doesn't exist, that language doesn't get a page." Only entries below are
+// shipped; Python / Go / Rust / Hugo / Astro etc. are deliberately absent until
+// real reference implementations ship.
+
+export type ImplementationKind = 'cli' | 'library' | 'integration';
+export type ImplementationStatus = 'live' | 'pre-launch';
+export type PackageRegistry = 'npm-public' | 'github-packages-prelaunch' | 'n/a';
+
+export interface Implementation {
+  slug: string;
+  title: string;
+  kind: ImplementationKind;
+  oneLine: string;
+  packageName?: string;
+  packageRegistry: PackageRegistry;
+  repoUrl?: string;
+  status: ImplementationStatus;
+  statusNote?: string;
+  install: string;
+  usage: { heading: string; lang: string; code: string; note?: string }[];
+  body: string[];
+  coversTopics: string[];
+}
+
+export const IMPLEMENTATIONS: Implementation[] = [
+  {
+    slug: 'integrity-cli',
+    title: 'integrity-cli — Layer 2 reference runner',
+    kind: 'cli',
+    oneLine:
+      'The reference runner for the v1 Layer 2 architectural constraints. Pure ESM, zero deps, deterministic, no LLM, no network. Apache-2.0.',
+    packageName: '@startvest/integrity-cli',
+    packageRegistry: 'npm-public',
+    repoUrl: 'https://github.com/Startvest-LLC/startvest-integrity-cli',
+    status: 'live',
+    install: 'npm install -g @startvest/integrity-cli',
+    usage: [
+      {
+        heading: 'One-shot run via npx',
+        lang: 'bash',
+        code: 'npx @startvest/integrity-cli check ./your-repo',
+        note: 'No install needed. Exits 0 on pass; 1 on CRITICAL findings; 2 on HIGH (with --strict).',
+      },
+      {
+        heading: 'Run base manifest only',
+        lang: 'bash',
+        code: 'integrity check ./your-repo --base-only --format=json',
+        note: 'CI-consumable JSON output. Skip per-product manifests; run only the v1.0 base rule set.',
+      },
+      {
+        heading: 'Browse the directory',
+        lang: 'bash',
+        code: 'integrity directory list\nintegrity directory show your-listing-slug',
+        note: 'Reads https://theintegrityframework.org/api/listings.json. Read-only.',
+      },
+    ],
+    body: [
+      'integrity-cli is the canonical reference implementation of Layer 2. The base manifest at manifests/base-v1.json contains the rules that any framework-conformant codebase has to pass; per-product manifests extend with codebase-specific rules.',
+      "Deterministic by design. No LLM, no network calls during a check. Same inputs always produce the same findings. This is the property that makes the runner usable as a CI gate — non-determinism in a CI gate would itself be a Layer 2 failure.",
+      "The runner backs the directory's Silver-tier verification path: a green run on a public repo is one of the two acceptable Silver credentials, alongside a versioned methodology page.",
+    ],
+    coversTopics: [
+      'evidence-chain-integrity',
+      'ai-output-review-gates',
+      'customer-attestation-isolation',
+      'failure-transparency',
+      'reproducibility',
+    ],
+  },
+  {
+    slug: 'github-actions',
+    title: 'GitHub Actions integration',
+    kind: 'integration',
+    oneLine:
+      "Run integrity-cli on every push or PR. The job fails the build when a CRITICAL rule fails — closing the loop between Layer 2 and CI.",
+    packageRegistry: 'n/a',
+    status: 'live',
+    install:
+      "# .github/workflows/integrity.yml — drop-in workflow.\n# integrity-cli is on public npm; no auth needed.",
+    usage: [
+      {
+        heading: 'Minimal workflow',
+        lang: 'yaml',
+        code: `name: integrity
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx @startvest/integrity-cli check . --format=json --strict`,
+        note: 'Default exit codes: 0 pass, 1 CRITICAL fail, 2 HIGH fail (--strict), 3 usage error.',
+      },
+      {
+        heading: 'Per-product manifest',
+        lang: 'yaml',
+        code: `      - run: |
+          npx @startvest/integrity-cli check . \\
+            --format=json \\
+            --strict \\
+            --manifest .integrity/manifest.json`,
+        note: "If your repo carries a custom manifest, point at it explicitly. Per-product rules layer on top of the base manifest.",
+      },
+    ],
+    body: [
+      'GitHub Actions is the canonical CI host for the framework reference workflow. Most case-study products (ClarityLift, FieldLedger, adacompliancedocs) already run integrity-cli on every push; the workflows are visible in those public repos.',
+      "The workflow is intentionally trivial. The interesting work is in the base manifest and the per-product rules — the CI host is just the trigger and the gate. Equivalent workflows for GitLab CI, CircleCI, and Buildkite are mechanical translations.",
+      'Failed scans show as a red check on the PR. The standard pattern is to require the integrity check on the protected branch — that turns Layer 2 from a guideline into a structural commitment.',
+    ],
+    coversTopics: [
+      'failure-transparency',
+      'reproducibility',
+      'evidence-chain-integrity',
+    ],
+  },
+  {
+    slug: 'typescript-node-brief-core',
+    title: 'brief-core — TypeScript / Node reference parser',
+    kind: 'library',
+    oneLine:
+      'Reference parser, resolver, and renderer for the brief.md spec. Pure TypeScript. Zero infrastructure dependencies.',
+    packageName: '@theintegrityframework/brief-core',
+    packageRegistry: 'github-packages-prelaunch',
+    repoUrl: 'https://github.com/theintegrityframework/brief-core',
+    status: 'pre-launch',
+    statusNote:
+      'Repo is private; package is published to GitHub Packages under restricted access until the brief.md spec goes public on AppSumo launch day. After launch the package moves to public npm.',
+    install:
+      'echo "@theintegrityframework:registry=https://npm.pkg.github.com" >> .npmrc\nnpm install @theintegrityframework/brief-core',
+    usage: [
+      {
+        heading: 'Parse, resolve, render',
+        lang: 'typescript',
+        code: `import {
+  parseBrief,
+  resolveBrief,
+  renderBrief,
+  assertNoLeakage,
+  validateVoice,
+} from '@theintegrityframework/brief-core';
+
+const operator = parseBrief(operatorMd);
+const brand = parseBrief(brandMd);
+const resolved = resolveBrief(operator, brand);
+
+// Render the public-scope subset for an AI consumer
+const publicView = renderBrief(resolved, 'public');
+assertNoLeakage(publicView, 'public');  // throws if anything leaked
+
+// Validate a draft against voice rules
+const report = validateVoice(draftText, resolved, 'pitch');`,
+        note: 'Five exports cover the full spec lifecycle: parse, resolve, render, leakage-check, voice-validate.',
+      },
+    ],
+    body: [
+      'brief-core is the v0.1 reference implementation of the brief.md spec. Pure TypeScript means no native dependencies and a small surface; zero infra dependencies means it runs in any Node 20+ environment, including serverless and Workers.',
+      "Implementations in other languages should aim for byte-identical output on the same input. brief-core's test suite is the conformance suite — a Python or Go parser passes when it matches the brief-core output on the same fixtures.",
+      "The package status is pre-launch: it's published to GitHub Packages under restricted access until the brief.md spec goes public, at which point it mirrors to public npm. Code, tests, and documentation are real and complete; the gating is on the spec publication date.",
+    ],
+    coversTopics: [
+      'public-methodology-documentation',
+      'reproducibility',
+      'independent-verification-hooks',
+    ],
+  },
+  {
+    slug: 'brief-cli',
+    title: 'brief-cli — author and validate brief.md',
+    kind: 'cli',
+    oneLine:
+      'Reference command-line tool for the brief.md spec. Author from a URL, validate against the v0.1 spec, resolve operator + brand inheritance.',
+    packageName: '@theintegrityframework/brief-cli',
+    packageRegistry: 'github-packages-prelaunch',
+    repoUrl: 'https://github.com/theintegrityframework/brief-cli',
+    status: 'pre-launch',
+    statusNote:
+      'Pre-launch alongside brief-core. Mirrors to public npm + Homebrew tap + standalone release binaries on AppSumo launch day.',
+    install:
+      'echo "@theintegrityframework:registry=https://npm.pkg.github.com" >> ~/.npmrc\nnpm install -g @theintegrityframework/brief-cli',
+    usage: [
+      {
+        heading: 'Generate a draft from a URL',
+        lang: 'bash',
+        code: 'brief init https://yourcompany.com\n# writes ./brand-brief.md',
+        note: 'Quality target: 60–70% of fields useful, the rest left as <TODO> placeholders. Removes the blank-page tax.',
+      },
+      {
+        heading: 'Validate a brief.md',
+        lang: 'bash',
+        code: 'brief validate ./brand-brief.md\nbrief validate ./brand-brief.md --quiet  # for pre-commit hooks',
+        note: 'Exit codes: 0 valid, 1 invalid, 2 usage error, 3 runtime error.',
+      },
+      {
+        heading: 'Pre-commit hook',
+        lang: 'yaml',
+        code: `# .pre-commit-config.yaml
+- repo: local
+  hooks:
+    - id: brief-validate
+      name: validate brief.md
+      language: system
+      entry: brief validate
+      files: ^brand-brief\\.md$`,
+        note: "The CLI's exit codes are designed for hooks. Quiet mode prints only errors.",
+      },
+    ],
+    body: [
+      'brief-cli is the authoring and validation surface for brief.md. It wraps brief-core with terminal ergonomics — a `brief init` command that scrapes a URL into a draft, a `brief validate` command that backs pre-commit hooks, and a `brief resolve` command that inheritance-merges operator and brand briefs.',
+      'The CLI is a thin layer over the library. Nothing it does is unavailable to a Node program importing brief-core directly; the value is in the ergonomics for non-Node authors and in the standardized exit codes that make the tool drop-in for CI pipelines.',
+      'Like brief-core, the CLI is pre-launch — the package code is real and complete, gated on the brief.md spec publication date. Post-launch, install paths multiply: public npm, Homebrew tap, and standalone release binaries.',
+    ],
+    coversTopics: ['public-methodology-documentation', 'reproducibility'],
+  },
+  {
+    slug: 'integrity-md',
+    title: 'INTEGRITY.md — the authoring surface',
+    kind: 'integration',
+    oneLine:
+      "The per-product self-mapping document. Sits in the repo root, names every Layer 1 veto and Layer 2 constraint with implementation status, file paths, and CI rule names.",
+    packageRegistry: 'n/a',
+    status: 'live',
+    install:
+      "# INTEGRITY.md is a markdown convention, not a package. The reference\n# template lives in the framework repo's INTEGRITY.md.",
+    usage: [
+      {
+        heading: 'Minimum viable shape',
+        lang: 'markdown',
+        code: `# INTEGRITY.md
+
+This product operates under [The Integrity Framework v1.0](https://theintegrityframework.org/framework/v1).
+
+## Layer 1 vetoes
+
+### Artifact vs outcome
+**Status:** PASS — pricing is per-engagement, not per-artifact. See \`docs/pricing.md\`.
+
+### Independence
+**Status:** PASS — we do not certify our own customers. See \`docs/positioning.md\`.
+
+[... continue for all six vetoes]
+
+## Layer 2 constraints
+
+### Evidence chain integrity
+**Status:** PASS — \`schema.sql\` line 42 enforces non-null FK from claims to evidence. CI rule: \`SV-EVIDENCE-CHAIN-FK\`.
+
+[... continue for all seven constraints]`,
+        note: "Status is one of PASS, PARTIAL, NOT-YET, or N/A. PARTIAL and NOT-YET name the close date.",
+      },
+    ],
+    body: [
+      "INTEGRITY.md is how a product publishes its self-mapping against the framework. Every Layer 1 veto and Layer 2 constraint is named, with a status, a file path or CI rule pointing at the implementation, and (for partials) a close date.",
+      "It's the lowest-overhead implementation surface. Bronze-tier listings on the directory require a public INTEGRITY.md self-mapping the six Layer 1 vetoes; Silver requires Bronze plus either an integrity-cli green run or a versioned methodology page.",
+      "Roughly half a day of honest reflection and writing for a thoughtful founder. The artifact survives the team — it's a structural commitment readable by procurement reviewers, future engineers, and the framework's own re-scan workflow.",
+    ],
+    coversTopics: [
+      'public-methodology-documentation',
+      'public-kill-criteria',
+      'techcrunch-test',
+    ],
+  },
+];
+
+export function getAllImplementationSlugs(): string[] {
+  return IMPLEMENTATIONS.map((i) => i.slug);
+}
+
+export function getImplementationBySlug(slug: string): Implementation | undefined {
+  return IMPLEMENTATIONS.find((i) => i.slug === slug);
+}

--- a/src/lib/spec-topics.ts
+++ b/src/lib/spec-topics.ts
@@ -1,0 +1,549 @@
+// Spec topic data. Every entry cites a section of the published v1.0 framework
+// at /framework/v1. If you change wording in the spec, bump specVersion or fix
+// the citation here. Drop rule: a spec page that can't cite the exact published
+// section is dropped, not shipped.
+
+export const SPEC_VERSION = '1.0';
+export const SPEC_LAST_UPDATED = '2026-04-25';
+
+export type SpecLayer = 'failure-mode' | 'layer-1' | 'layer-2' | 'layer-3';
+
+export interface SpecTopic {
+  slug: string;
+  title: string;
+  layer: SpecLayer;
+  layerLabel: string;
+  specSection: string;
+  specAnchor: string;
+  oneLine: string;
+  passes: string;
+  fails: string;
+  body: string[];
+  relatedCases?: string[];
+  relatedTopics?: string[];
+}
+
+export const SPEC_TOPICS: SpecTopic[] = [
+  // ---------- Failure modes (5) ----------
+  {
+    slug: 'trust-arbitrage-failure',
+    title: 'Trust-arbitrage failure',
+    layer: 'failure-mode',
+    layerLabel: 'Failure mode',
+    specSection: 'Failure modes — 1 of 5',
+    specAnchor: 'failure-modes',
+    oneLine:
+      'Selling certification artifacts as the product instead of the underlying outcomes. Volume-based business models destroy rigor over time.',
+    passes:
+      'Pricing is tied to actual verification work. Customers buy outcomes (audit-readiness, real compliance state) — not badges and reports.',
+    fails:
+      'Pricing is tied to artifact count. The product hits its revenue plan by issuing more reports, regardless of whether the underlying state changed.',
+    body: [
+      'The first of five failure modes the framework is reverse-engineered from. The pattern recurs across compliance categories — the artifact (a certificate, a badge, a report) is sold as if it were the outcome (genuine compliance, genuine security). Volume-based pricing then quietly forces the rigor down.',
+      "Theranos sold 'lab results' as the product; the lab work behind them was the actual outcome, and the gap was the failure. Crossfit-style certifications sold the cert; the operator skill was the outcome. Once the artifact is what's monetized, every incremental sale is a downward pressure on the rigor that produced it.",
+      'Layer 1 Veto 1 (artifact-vs-outcome) is the structural defense. Layer 3 guardrail (refund-on-failure) is the financial defense — when the artifact turns out wrong, the vendor pays. Together they make trust-arbitrage uneconomic.',
+    ],
+    relatedTopics: ['artifact-vs-outcome', 'refund-on-failure', 'pricing-rigor-alignment'],
+  },
+  {
+    slug: 'theater-vs-substance-failure',
+    title: 'Theater versus substance failure',
+    layer: 'failure-mode',
+    layerLabel: 'Failure mode',
+    specSection: 'Failure modes — 2 of 5',
+    specAnchor: 'failure-modes',
+    oneLine:
+      "Outputs that look like compliance but don't verify the underlying state. Checklists checked without verification, evidence collected without inspection.",
+    passes:
+      'Every claim on every output is traceable to specific evidence the product collected and timestamped. A reviewer can walk the chain.',
+    fails:
+      'Outputs read as if checks happened. The underlying evidence is missing, stale, or never inspected. Theater.',
+    body: [
+      "The second failure mode. Looks like compliance, smells like compliance, doesn't actually verify the underlying state. The Delve case study is the canonical example: attestation fields populated before the customer evidence existed, output looking finished while the substance behind it was empty.",
+      "Layer 2 architectural constraint 1 (evidence chain integrity) is the structural defense — every claim must be traceable to specific evidence the product collected. Layer 2 constraint 7 (failure transparency) is the disclosure defense — when the product can't verify, it MUST say so, never silently default to 'compliant'.",
+      'Theater is what catches procurement reviewers who actually read the output. Substance is what survives the audit when someone walks the chain.',
+    ],
+    relatedCases: ['delve'],
+    relatedTopics: ['evidence-chain-integrity', 'failure-transparency', 'verifiability'],
+  },
+  {
+    slug: 'conflict-of-interest-failure',
+    title: 'Conflict-of-interest failure',
+    layer: 'failure-mode',
+    layerLabel: 'Failure mode',
+    specSection: 'Failure modes — 3 of 5',
+    specAnchor: 'failure-modes',
+    oneLine:
+      'Verifier paid by the verified entity, with no structural independence. The Andersen / Enron pattern.',
+    passes:
+      "Customer pays the vendor for tooling that prepares the customer for verification by genuinely independent third parties. Vendor doesn't certify its own customers.",
+    fails:
+      'Customer pays the vendor to BOTH prepare AND certify. The same entity collects fees and issues the verdict.',
+    body: [
+      'The third failure mode, and the one with the most-studied historical precedent. Arthur Andersen audited Enron while collecting consulting fees from Enron. The structural conflict made the rigor uneconomic, and the entire firm collapsed when the conflict surfaced.',
+      'Layer 1 Veto 2 (independence) is the bright-line defense. The framework treats this as a hard rule, not a negotiable: the vendor must not certify its own customers. Tooling-to-prepare-for-third-party-verification is fine; tooling-and-certification-from-the-same-vendor is the failure mode.',
+      'This veto is the single biggest selection filter on what products qualify under the framework. It rules out an entire product shape that would otherwise generate revenue.',
+    ],
+    relatedTopics: ['independence', 'pricing-rigor-alignment', 'annual-independent-audit'],
+  },
+  {
+    slug: 'black-box-ai-failure',
+    title: 'Black-box AI failure',
+    layer: 'failure-mode',
+    layerLabel: 'Failure mode',
+    specSection: 'Failure modes — 4 of 5',
+    specAnchor: 'failure-modes',
+    oneLine:
+      "AI producing compliance outputs without humans understanding what was done, why, or whether it's correct. Unique to current-generation compliance work.",
+    passes:
+      'AI outputs pass through documented review gates before becoming attestations. The review gate is a CI rule or schema field, not a policy.',
+    fails:
+      'AI output reaches a customer-facing claim directly. The review gate is a training, a checklist, or a vibe.',
+    body: [
+      "The fourth failure mode is the new one. Until ~2023 it didn't exist at industry scale; current-generation LLMs made it cheap to produce convincing compliance outputs faster than humans can review them.",
+      'Layer 1 Veto 4 (AI accountability) is the structural defense at the pre-build level — the human review layer must exist by design. Layer 2 constraint 2 (AI output review gates) is the CI-enforced version: the review gate is a database column, a non-null foreign key, or a forbidden-pattern check that blocks the bypass at build time.',
+      "Policy-only review gates fail under load. The product ships fast, the gate becomes a training nobody completes, and AI output starts flowing to customers unreviewed. Structural enforcement — the build fails when the gate is bypassed — is the only durable form.",
+    ],
+    relatedTopics: ['ai-accountability', 'ai-output-review-gates', 'failure-transparency'],
+  },
+  {
+    slug: 'velocity-over-rigor-failure',
+    title: 'Velocity-over-rigor failure',
+    layer: 'failure-mode',
+    layerLabel: 'Failure mode',
+    specSection: 'Failure modes — 5 of 5',
+    specAnchor: 'failure-modes',
+    oneLine:
+      'Business pressure to ship audits or certifications faster than they can be done well. Speed claims become trust claims become fraud.',
+    passes:
+      "Pricing is tied to work performed, not to a calendar. Per-engagement billing keeps the math honest about how long rigor takes.",
+    fails:
+      "'Unlimited audits for $X/year.' The model only works if audits get fast, and fast-enough audits stop being audits.",
+    body: [
+      'The fifth failure mode is the slow one. Volume pricing on rigorous work is a structural promise that rigor will degrade. The math forces it: if the price is fixed, every additional audit reduces per-audit time, and at some point the audit becomes a checklist scan that gets called an audit because that\'s what the contract calls it.',
+      'Layer 1 Veto 5 (pricing-rigor alignment) is the defense at the pricing-model level. Volume pricing on rigorous outputs fails this veto by definition.',
+      "This is the failure mode least likely to be visible at year 1. The vendor ships, sells, the audits feel rushed but acceptable. By year 3 the audits are checkboxes, the vendor is trapped in the pricing model, and everyone's compliance posture is worse than it would have been without the vendor.",
+    ],
+    relatedTopics: ['pricing-rigor-alignment', 'artifact-vs-outcome', 'public-kill-criteria'],
+  },
+
+  // ---------- Layer 1: pre-build vetoes (6) ----------
+  {
+    slug: 'artifact-vs-outcome',
+    title: 'Veto 1: artifact versus outcome',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 1 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      'Is the value proposition selling an artifact (report, badge, score) or an outcome (actual compliance, security, audit-readiness)? Outcome passes. Artifact fails.',
+    passes:
+      "Outcome — customer's underlying state is genuinely better. The artifact is a side-effect of the outcome, not the product itself.",
+    fails:
+      "Artifact — customer pays for the badge / report / score. Whether the underlying state changed is incidental to the transaction.",
+    body: [
+      "The first pre-build veto. Six questions get answered before a product gets built or before a major scope expansion; this is the first. Wrong answer kills the product, not delays it.",
+      "The bright line: would a customer who needed the OUTCOME pay for it independently of the ARTIFACT? If yes, the product is selling outcomes. If the only reason to buy is to hold the artifact (a SOC 2 logo, a HIPAA-certified badge), the product is selling artifacts and fails this veto.",
+      'A product failing this veto either gets reframed before build or gets passed on. The framework is more important than any single revenue line — Startvest passes on otherwise-attractive opportunities here regularly.',
+    ],
+    relatedTopics: ['trust-arbitrage-failure', 'verifiability', 'pricing-rigor-alignment'],
+  },
+  {
+    slug: 'independence',
+    title: 'Veto 2: independence',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 2 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      'Who pays us, and does that conflict with what we verify? Tooling to prepare for independent third-party verification: pass. Same vendor preparing AND certifying: fail.',
+    passes:
+      "Customer pays for tooling that prepares them for verification by a genuinely independent third party. The vendor doesn't issue the certification.",
+    fails:
+      'Vendor takes payment to prepare the customer AND to certify the customer. Same entity, both sides of the transaction. Andersen / Enron.',
+    body: [
+      'The second pre-build veto. Hard rule, not negotiable. The framework treats independence as the bright line that filters out an entire shape of product, regardless of revenue potential.',
+      "The historical precedent (Arthur Andersen / Enron) is concrete: an audit firm collecting consulting fees from the audit subject can't credibly issue independent verdicts. The structure forces the rigor to degrade, and eventually the firm collapses with the conflict.",
+      'In Startvest products, this veto rules out the certification-as-a-service model entirely. ClarityLift ships preparation tooling for SOC 2 audits — the audit is performed by an independent CPA firm. The framework requires the same of every product operating under it.',
+    ],
+    relatedTopics: ['conflict-of-interest-failure', 'annual-independent-audit', 'customer-side-compliance-owner'],
+  },
+  {
+    slug: 'verifiability',
+    title: 'Veto 3: verifiability',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 3 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      'Can we mechanically verify what we claim, or are we relying on customer attestation alone? Mechanical: pass. Attestation as proof: fail.',
+    passes:
+      "Claims are backed by evidence the product itself collected and can re-check. Attestation is supplementary, never primary.",
+    fails:
+      "The claim's only basis is that the customer said it. The product has no independent way to confirm or re-confirm.",
+    body: [
+      "The third pre-build veto. The internal portfolio audits surfaced an important refinement to this veto: the input-data-provenance vs output-attestation-provenance distinction (see the Hireposture case study). Customer attestation IS valid for input data — but the output the product publishes can't be solely attestation-backed.",
+      "Mechanical verification means a build-time, runtime, or scheduled re-check. The product can re-prove the claim today without asking the customer again.",
+      'The fifth internal portfolio audit (adacompliancedocs) surfaced a structurally new shape of this veto — the customer-attestation-validation-gate: a customer-attested status field cannot publish until system-verified evidence supports it. That shape became the third C3 axis in base manifest v1.9.0.',
+    ],
+    relatedCases: ['hireposture', 'adacompliancedocs'],
+    relatedTopics: ['evidence-chain-integrity', 'customer-attestation-isolation', 'theater-vs-substance-failure'],
+  },
+  {
+    slug: 'ai-accountability',
+    title: 'Veto 4: AI accountability',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 4 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      "When AI gets it wrong, what's the human review layer and escalation path? AI through documented review gates: pass. AI direct to customer-facing claim: fail.",
+    passes:
+      'AI outputs pass through documented review gates before becoming attestations, reports, or customer-facing claims. The review gate is structurally enforced.',
+    fails:
+      "AI output reaches the customer directly. The 'review gate' is a policy, a training, or a one-time prompt-engineering exercise.",
+    body: [
+      "The fourth pre-build veto. This veto is the new one — current-generation AI made it cheap to produce compliance-shaped output faster than humans can read, let alone verify. Without a review layer, the failure mode is automatic.",
+      "The veto sits at the pre-build level because it's a design question, not an implementation question. A product designed without a review layer can't add one later without re-architecting; a product designed WITH a review layer survives the volume pressure that would have shipped unreviewed AI output.",
+      'Layer 2 constraint 2 (AI output review gates) is the CI-enforced version of this veto. Where the architecture allows, the review gate is a non-null foreign key or a required-field check; the build fails when the gate is bypassed.',
+    ],
+    relatedTopics: ['black-box-ai-failure', 'ai-output-review-gates', 'failure-transparency'],
+  },
+  {
+    slug: 'pricing-rigor-alignment',
+    title: 'Veto 5: pricing-rigor alignment',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 5 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      'Does our pricing model create financial pressure to skip work? Pricing tied to actual work performed: pass. "Unlimited audits for $X/year": fail.',
+    passes:
+      'Pricing scales with the rigor performed. More work, more revenue. Less work, less revenue. The math doesn\'t pressure anyone to cut corners.',
+    fails:
+      "Pricing is fixed and the product is rigorous work. Every additional unit reduces per-unit time. Eventually, per-unit time becomes too small to do the work properly.",
+    body: [
+      "The fifth pre-build veto. The defense against velocity-over-rigor failure at the pricing-model level.",
+      "Volume pricing on rigorous outputs is a structural promise that rigor will degrade. The math forces it. A vendor selling 'unlimited audits' for a flat fee has already committed to making audits cheaper to produce than to do well.",
+      'Per-engagement and per-evidence billing pass this veto. SaaS subscriptions for tooling that supports rigorous work pass too. Subscriptions where the deliverable is the rigorous work itself — that fails.',
+    ],
+    relatedTopics: ['velocity-over-rigor-failure', 'artifact-vs-outcome', 'refund-on-failure'],
+  },
+  {
+    slug: 'techcrunch-test',
+    title: 'Veto 6: the TechCrunch test',
+    layer: 'layer-1',
+    layerLabel: 'Layer 1 — Pre-build veto',
+    specSection: 'Layer 1, Veto 6 of 6',
+    specAnchor: 'layer-1',
+    oneLine:
+      'Imagine the worst-case headline about this product in 18 months. Can we defend every claim, methodology, and output? Concrete defense: pass. Hand-waving: fail.',
+    passes:
+      'Every claim, every methodology, every output survives the worst-faith reading. The defense is files, dates, evidence chains.',
+    fails:
+      "The defense requires hand-waving, context-setting, or 'we never said it that way.' The TechCrunch headline is going to land.",
+    body: [
+      "The sixth and final pre-build veto. A reverse-engineered question — instead of asking 'can we build this and ship', ask 'can we still defend this in 18 months when the worst possible reading lands as a headline?'",
+      "The 18-month horizon is calibrated to the average compliance-product time-to-incident. Most categories experience their first public-failure event in months 12-24 after seeing real volume; this veto runs the failure mode forward in time and asks whether the defense holds up.",
+      "A product passing this veto has its defenses in place by design. A product failing it has the defense as a hope. Hope-based defenses lose to journalists with public records.",
+    ],
+    relatedTopics: ['public-methodology-documentation', 'failure-transparency', 'public-kill-criteria'],
+  },
+
+  // ---------- Layer 2: architectural constraints (7) ----------
+  {
+    slug: 'evidence-chain-integrity',
+    title: 'Constraint 1: evidence chain integrity',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 1 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Every compliance claim traceable to specific evidence the product collected and timestamped.',
+    passes:
+      'Every claim row in the output has a non-null foreign key to an evidence row. The build fails when the foreign key is null.',
+    fails:
+      "Claims exist; the evidence behind them is implicit, missing, or stored in a different system the product can't re-walk.",
+    body: [
+      'The first Layer 2 constraint, CI-enforced where the codebase shape allows. Evidence-chain integrity becomes a non-null foreign key; the database schema makes the claim-without-evidence shape unrepresentable.',
+      'This constraint is the structural defense against theater-vs-substance failure. A claim that lacks specific evidence is a theater claim by definition; if the schema forbids it, the failure mode is impossible to ship.',
+      'The reference runner for this and the other Layer 2 constraints is integrity-cli. The base manifest implements evidence-chain checks as both schema-level (foreign key required) and content-level (no claim-strings without evidence-strings in adjacent positions) rules.',
+    ],
+    relatedTopics: ['theater-vs-substance-failure', 'reproducibility', 'failure-transparency'],
+  },
+  {
+    slug: 'ai-output-review-gates',
+    title: 'Constraint 2: AI output review gates',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 2 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Any AI-generated compliance output passes through human review before becoming an attestation, report, or customer-facing claim.',
+    passes:
+      "AI outputs are stored in a 'pending-review' state that requires a reviewer signature before becoming customer-facing. The state machine is enforced at the schema level.",
+    fails:
+      'AI output writes directly to the customer-facing field. Review is a policy, a training, or a UI hint.',
+    body: [
+      "The second Layer 2 constraint. The CI-enforced version of Layer 1's AI-accountability veto. Policy alone fails under volume; structural enforcement is the only durable form.",
+      "The reference shape is a state machine: AI output enters as 'pending-review', a reviewer's user_id signs the row to move it to 'reviewed', and only 'reviewed' rows are visible to the customer-facing surface. The reviewer-signature column is non-null on the customer-facing query.",
+      "integrity-cli's base manifest carries this as a content-rule check across compliance products: the existence of an AI-output table or column without a paired reviewer-signature column is a HIGH finding.",
+    ],
+    relatedTopics: ['ai-accountability', 'black-box-ai-failure', 'evidence-chain-integrity'],
+  },
+  {
+    slug: 'customer-attestation-isolation',
+    title: 'Constraint 3: customer self-attestation isolation',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 3 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Customer-attested data visually and architecturally distinct from product-verified data.',
+    passes:
+      "Two table families: customer_attested_* and product_verified_*. The UI surfaces them with different visual treatment. A reviewer can't confuse attestation with verification.",
+    fails:
+      'Single mixed table. UI presents attestation and verification as the same kind of evidence. A reviewer reads the customer-attested field as if the product had verified it.',
+    body: [
+      "The third Layer 2 constraint. Surfaced as structurally important by the Hireposture audit (Hireposture is a candidate-data product where the input is necessarily attested, but the output attestation has different provenance). Drove base manifest v1.8.0 — accepting snake_case marker variants like signed_by_user_id and customer_attested.",
+      "The architectural shape: distinct table prefixes, distinct UI components, distinct API field names. The reviewer can tell at a glance which data the product verified and which the customer attested.",
+      "The fifth portfolio audit (adacompliancedocs, v1.9.0) extended this constraint with the validation-gate axis: a customer-attested status field cannot publish until system-verified evidence supports it.",
+    ],
+    relatedCases: ['hireposture', 'adacompliancedocs'],
+    relatedTopics: ['verifiability', 'evidence-chain-integrity'],
+  },
+  {
+    slug: 'reproducibility',
+    title: 'Constraint 4: reproducibility',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 4 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Every audit conclusion reproducible from underlying evidence by an independent reviewer. Internal review gates test reproducibility quarterly.',
+    passes:
+      "An external reviewer, given the evidence files alone, arrives at the same conclusion the product produced. Quarterly internal test confirms.",
+    fails:
+      "The conclusion depends on internal product state, undocumented logic, or one-time AI output that can't be re-run with the same inputs.",
+    body: [
+      "The fourth Layer 2 constraint. The defense against the closed-system failure where the only entity who can reproduce the conclusion is the product itself.",
+      "Reproducibility is tested quarterly inside Startvest. A random sample of conclusions gets re-walked by a non-author reviewer using only the evidence files. If the conclusion doesn't reproduce, the issue is filed and the underlying system is fixed before the next cycle.",
+      "This constraint is what makes Layer 3 guardrail 3 (annual third-party audit) actually possible. An auditor can verify the product's outputs only if the outputs are reproducible from the evidence the product surfaces.",
+    ],
+    relatedTopics: ['evidence-chain-integrity', 'independent-verification-hooks', 'annual-independent-audit'],
+  },
+  {
+    slug: 'evidence-retention-independence',
+    title: 'Constraint 5: evidence retention independence',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 5 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Evidence supporting compliance claims retained per statutory requirements regardless of normal data lifecycle. Customer offboarding does NOT delete audit evidence.',
+    passes:
+      'Evidence storage is on a retention schedule independent of the customer lifecycle. Offboarding triggers redaction of PII; the audit chain itself is preserved per statutory rule.',
+    fails:
+      'Customer offboarding deletes the evidence chain. The audit becomes unverifiable as soon as the customer leaves.',
+    body: [
+      'The fifth Layer 2 constraint. A subtle one — most retention schedules in SaaS are tied to the customer lifecycle, but compliance evidence has its own statutory retention requirement that survives offboarding.',
+      'The architectural shape: evidence storage is logically distinct from customer-data storage. PII gets redacted on offboarding per privacy rules; the audit-chain skeleton (timestamps, claim-IDs, evidence-hashes) is retained per the longer compliance schedule.',
+      "Without this constraint, the historical claims a product made become unverifiable the moment the customer leaves. The audit chain is only as durable as the storage policy that defends it.",
+    ],
+    relatedTopics: ['evidence-chain-integrity', 'reproducibility'],
+  },
+  {
+    slug: 'independent-verification-hooks',
+    title: 'Constraint 6: independent verification hooks',
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 6 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      'Every compliance product has a mode where an external auditor can verify product outputs without the product mediating.',
+    passes:
+      "An external auditor receives a read-only export with claim-rows, evidence-rows, hashes, and timestamps. They can verify outputs against evidence without the product's UI.",
+    fails:
+      "Verification requires the product's UI to function. The auditor sees only what the product chooses to show.",
+    body: [
+      'The sixth Layer 2 constraint. The product must have a mode where it gets out of the way and lets the auditor walk the chain directly.',
+      "The reference shape is a verifier-export: a read-only bundle (often JSON Lines plus a hash manifest) of claim-rows, evidence-rows, and the linkage between them. The auditor's verification tooling consumes the bundle and re-walks the chain without the product mediating.",
+      "This constraint is what makes Layer 3 guardrail 3 (annual third-party audit) economically tractable. Without verification hooks the auditor needs custom integration with the product; with them the audit is a script run.",
+    ],
+    relatedTopics: ['reproducibility', 'annual-independent-audit', 'public-methodology-documentation'],
+  },
+  {
+    slug: 'failure-transparency',
+    title: "Constraint 7: failure transparency",
+    layer: 'layer-2',
+    layerLabel: 'Layer 2 — Architectural constraint',
+    specSection: 'Layer 2, Constraint 7 of 7',
+    specAnchor: 'layer-2',
+    oneLine:
+      "When the product can't verify something, it MUST say so. Never silently default to 'compliant' when verification fails.",
+    passes:
+      "The product surfaces unknowns explicitly: 'unverified', 'evidence missing', 'check timed out'. The customer-facing surface distinguishes verified from not-verified-yet.",
+    fails:
+      "On verification failure, the product silently emits 'compliant' or 'pass'. The unknown becomes an implicit positive.",
+    body: [
+      'The seventh Layer 2 constraint. The architectural defense against the catch-and-default-to-true pattern that destroys evidence chains.',
+      "The CI rule shape: forbidden-pattern check on `catch { return verified: true }` and similar shapes. The build fails when a catch block silently swallows verification failure into a positive verdict.",
+      "This constraint is one of the most-tested in the integrity-cli base manifest, because the failure mode is easy to write accidentally and hard to catch in code review without an explicit check.",
+    ],
+    relatedTopics: ['evidence-chain-integrity', 'theater-vs-substance-failure', 'ai-output-review-gates'],
+  },
+
+  // ---------- Layer 3: operational guardrails (7) ----------
+  {
+    slug: 'refund-on-failure',
+    title: 'Guardrail 1: refund-on-failure',
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 1 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      'Every customer contract includes a refund clause if our certification or verification turns out wrong because of our error or oversight.',
+    passes:
+      'The refund clause is in the standard MSA. The vendor can paste the clause on request without legal review.',
+    fails:
+      "Refund is only available on negotiated enterprise contracts. The default contract has no clause. 'We'd refund if it ever happened' is not a clause.",
+    body: [
+      'The first Layer 3 guardrail. The financial defense against velocity-over-rigor and trust-arbitrage. When the vendor pays for being wrong, the rigor stays economic.',
+      "Vendor scorecard row 2 (refund-on-failure clause in the standard MSA) maps to this guardrail. A vendor that ducks this row is operating outside the framework whether they claim it or not.",
+      "Startvest's three live products (ClarityLift, FieldLedger, adacompliancedocs) carry this as a baseline-published gap: the clause is drafted, finalization in flight. The gap is named on the operator self-grades section of the v1 spec, with the close date public.",
+    ],
+    relatedTopics: ['velocity-over-rigor-failure', 'pricing-rigor-alignment', 'public-kill-criteria'],
+  },
+  {
+    slug: 'public-methodology-documentation',
+    title: 'Guardrail 2: public methodology documentation',
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 2 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      'Every product publishes the methodology by which it produces compliance outputs. Not the source code, the methodology.',
+    passes:
+      'A versioned, changelogged methodology page. Linkable URL. Written so a procurement reviewer can verify each step.',
+    fails:
+      "No methodology page. Or the page exists but reads like marketing copy. Or it has no version and no changelog (silent drift).",
+    body: [
+      'The second Layer 3 guardrail. The transparency defense — the methodology must be public so the product can be checked against it.',
+      "The Vendor Scorecard's first row (public methodology page) maps to this guardrail. Versioned and changelogged is non-negotiable; a methodology that drifts silently is the failure mode the framework defends against.",
+      "The Integrity Framework's own /methodology page is the reference shape: the directory's evaluation criteria are themselves published as a versioned methodology. Eating the dog food.",
+    ],
+    relatedTopics: ['public-kill-criteria', 'techcrunch-test', 'independent-verification-hooks'],
+  },
+  {
+    slug: 'annual-independent-audit',
+    title: "Guardrail 3: annual independent audit",
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 3 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      'Once per year, every Startvest compliance product reviewed by a real third-party CPA firm or security firm. They sample our outputs. We publish findings, whatever they find.',
+    passes:
+      'Real CPA / security firm. Most recent audit shareable on request. Findings published, including the unflattering ones.',
+    fails:
+      "Only the audits the vendor SELLS to customers exist. The vendor itself is unaudited.",
+    body: [
+      'The third Layer 3 guardrail. The structural defense against grading your own homework.',
+      "Vendor Scorecard row 3 maps to this guardrail. The framework requires that the vendor publishing certification outputs is itself audited by an independent third party. Not a peer-review, not a self-attestation, not an internal audit team — an external firm with its own independence requirements.",
+      "Honest classification matters here. Startvest's three live products currently classify this row as NO with disclosure: the engagement cost is gated on external funding that does not currently exist. The row stays NO until that changes; relabeling it 'in flight' or 'scheduled' while funding is missing would be the failure mode itself.",
+    ],
+    relatedTopics: ['independence', 'reproducibility', 'independent-verification-hooks'],
+  },
+  {
+    slug: 'customer-side-compliance-owner',
+    title: "Guardrail 4: customer-side compliance owner",
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 4 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      "Before selling to a company, identify who there is responsible for the compliance outcome. We don't sell to companies where compliance is 'operations' problem.'",
+    passes:
+      "The customer has a named compliance owner — Compliance, Legal, Security, or named owner-operator. The owner signs off on the engagement.",
+    fails:
+      "No named owner. Compliance is 'something IT will figure out' or 'we'll add it to ops.' The vendor sells anyway.",
+    body: [
+      'The fourth Layer 3 guardrail. A discipline applied at the sales motion. Compliance products only work when there is a customer-side owner; without one, the product is shelfware regardless of how good the framework is.',
+      'This guardrail also defends against a downstream failure mode: when there is no compliance owner on the customer side, the vendor inevitably becomes the compliance owner by default. That collapses the independence required by Layer 1 Veto 2.',
+      "The qualification question gets asked at first call. If the answer is 'we don't have one', the vendor offers help finding one before continuing the sale, or declines.",
+    ],
+    relatedTopics: ['independence', 'conflict-of-interest-failure'],
+  },
+  {
+    slug: 'internal-whistleblower-channel',
+    title: 'Guardrail 5: internal whistleblower channel',
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 5 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      'Anonymous reporting channel monitored by independent counsel. Quarterly board-level review.',
+    passes:
+      'Real anonymous channel. Independent counsel monitors. Board reviews quarterly. The channel has a published contact path.',
+    fails:
+      "'Talk to your manager.' Or HR. Or the same exec the issue would be about.",
+    body: [
+      'The fifth Layer 3 guardrail. Internal-side defense against the failure modes that show up in compliance products before they show up to the customer.',
+      "Independent counsel, not internal counsel. The whole point is that the channel must work even when the conflict is at the top of the org chart. Internal counsel reports to the same exec the issue would be about.",
+      'Quarterly board-level review of the channel itself, not just of any reports filed. The framework treats the existence and health of the channel as itself a metric.',
+    ],
+    relatedTopics: ['independence', 'conflict-of-interest-failure', 'public-kill-criteria'],
+  },
+  {
+    slug: 'community-accountability-pattern',
+    title: 'Guardrail 6: community accountability pattern',
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 6 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      'Free tier or pack offered to a high-trust community that watches our work. Community will notice fakery.',
+    passes:
+      'A real high-trust community with eyes on the product. Veteran-owned business community for federal-contractor products. Disability-rights advocates for ADA products. Not a generic "free tier" with no engaged audience.',
+    fails:
+      "No specific community. The 'free tier' is a marketing funnel without engaged scrutiny.",
+    body: [
+      "The sixth Layer 3 guardrail. The external-side defense — a high-trust community watching the work catches fakery faster than auditors.",
+      "The community must be a fit for the product. Veteran-owned business community watches federal-contractor products. Disability-rights advocates watch ADA-compliance products. Public-sector orgs watch trust-adjacent products. Generic 'free tier' marketing funnels don't qualify; the community has to have specific reason to care and the access to notice.",
+      'Moat layer 5 (community accountability) on the eight-layer moat model maps to this guardrail. The framework treats community scrutiny as both a business moat AND an accountability mechanism — they are the same thing.',
+    ],
+    relatedTopics: ['public-methodology-documentation', 'public-kill-criteria'],
+  },
+  {
+    slug: 'public-kill-criteria',
+    title: 'Guardrail 7: public kill criteria',
+    layer: 'layer-3',
+    layerLabel: 'Layer 3 — Operational guardrail',
+    specSection: 'Layer 3, Guardrail 7 of 7',
+    specAnchor: 'layer-3',
+    oneLine:
+      "Every compliance product publishes the criteria under which we'd shut it down. Inverse of growth-at-all-costs.",
+    passes:
+      'Specific numbers, percentages, days, dates. Written down. Linkable URL. The vendor can be held to the criteria.',
+    fails:
+      "No kill criteria. Or vague 'we'd shut it down if it stopped working' language. Or criteria the vendor can quietly revise without a changelog.",
+    body: [
+      'The seventh Layer 3 guardrail. The structural commitment that the vendor will not chase revenue past the point where the product can be operated safely.',
+      'Vendor Scorecard row 6 maps to this guardrail. Specificity is non-negotiable: numbers, thresholds, dates. A criterion the vendor can hand-wave away is not a criterion.',
+      "Public kill criteria are inversion of growth-at-all-costs. They are also the inverse of the velocity-over-rigor failure mode at the business-decision level — when the vendor commits in advance to shutting down under specific conditions, the velocity pressure has a structural ceiling.",
+    ],
+    relatedTopics: ['velocity-over-rigor-failure', 'public-methodology-documentation', 'refund-on-failure'],
+  },
+];
+
+export function getAllSpecTopicSlugs(): string[] {
+  return SPEC_TOPICS.map((t) => t.slug);
+}
+
+export function getSpecTopicBySlug(slug: string): SpecTopic | undefined {
+  return SPEC_TOPICS.find((t) => t.slug === slug);
+}
+
+export function getSpecTopicsByLayer(layer: SpecLayer): SpecTopic[] {
+  return SPEC_TOPICS.filter((t) => t.layer === layer);
+}


### PR DESCRIPTION
## Summary
- **/spec** index + 25 spec topic pages — every page cites the published v1.0 spec section anchor (5 failure modes, 6 Layer 1 vetoes, 7 Layer 2 architectural constraints, 7 Layer 3 operational guardrails).
- **/implementation** index + 5 implementation guides — only real implementations: integrity-cli (live), GitHub Actions (live), brief-core (pre-launch), brief-cli (pre-launch), INTEGRITY.md (authoring convention). Drop rule honored — Python/Go/Rust deferred until real parsers ship.
- **/certifications** index + 3 tier pages (Bronze, Silver, Gold-deferred) mirroring the live `/methodology#tiers` wording.
- Sitemap wired for all new routes.

Total: 36 new SSG pages. Build clean, typecheck clean.

## Skipped, with reasoning
- **/signed-spec/[brand]** — `/framework/cases/[slug]` already covers portfolio-attested briefs (7 case studies). Building a parallel route would duplicate.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean — all 33 new routes prerendered (25 spec topics + 5 implementations + 3 certifications)
- [ ] Visual smoke test of `/spec`, `/spec/independence`, `/implementation/integrity-cli`, `/certifications/silver` after merge
- [ ] Confirm sitemap.xml includes new routes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)