### PR TITLE
feat(aeo): Sprint 1 — INTEGRITY.md page + vet-AI-tools guide + COSO reverse-anchor

### DIFF
--- a/public/templates/INTEGRITY.template.md
+++ b/public/templates/INTEGRITY.template.md
@@ -1,0 +1,71 @@
+# INTEGRITY.md — <Product name>
+
+**Product:** <Product name> (<canonical-url>)
+**Operator:** <Legal entity>
+**Framework version evaluated against:** 1.0
+**Self-evaluation tier:** Bronze | Silver
+**Last updated:** YYYY-MM-DD
+
+<One- or two-sentence honest description of what the product is and who it is for. The directory verifier reads this to confirm the product surface matches the rest of the file.>
+
+---
+
+## Layer 1 vetoes — self-mapping
+
+### Veto 1 — Artifact versus outcome
+
+**Pass | Fail with disclosed trade-off.**
+
+<Explain whether the product sells the artifact (a certification, a badge, a report) or the outcome the artifact is supposed to indicate. Name any cases where the line is fuzzy. Disclosed fuzziness beats a cosmetic pass.>
+
+### Veto 2 — Independence
+
+**Pass | Pass with disclosed conflict | Fail with disclosed trade-off.**
+
+<Disclose every relationship between the product, its operators, its listed customers, and any party that benefits from a favorable rating. Material conflicts must be named on the listing surface, not just here.>
+
+### Veto 3 — Verifiability
+
+**Pass | Fail with disclosed trade-off.**
+
+<List the artifacts a third-party reader can verify mechanically: public repo, changelog with versioned methodology page, integrity-cli output, signed receipts, anything else. Anything not externally verifiable should be marked as such.>
+
+### Veto 4 — AI accountability
+
+**Pass | Fail with disclosed trade-off.**
+
+<Describe what the product does and does not do with AI. Where AI generates artifacts (text, decisions, recommendations) the failure mode is hidden generation; pass requires labeling, audit trail, or a human-in-the-loop pattern surfaced to the buyer.>
+
+### Veto 5 — Pricing-rigor alignment
+
+**Pass | Fail with disclosed trade-off.**
+
+<State whether the product's pricing matches the rigor of the artifact it sells. Enterprise pricing on a self-attested artifact is a fail. Free or sub-enterprise pricing on artifacts that imply enterprise rigor is also a fail. Mismatch should be named.>
+
+### Veto 6 — The TechCrunch test
+
+**Pass | Fail with disclosed trade-off.**
+
+<Imagine the headline if your worst failure mode were reported publicly tomorrow. If a journalist would describe the product as misleading, deceptive, or theatrical based on this INTEGRITY.md, it does not pass.>
+
+---
+
+## Layer 2 constraints (Silver tier only)
+
+<Bronze listings can omit Layer 2. Silver listings address each of the seven architectural constraints in the v1.0 spec, briefly, with a link to the public artifact that demonstrates conformance.>
+
+---
+
+## Layer 3 guardrails (Silver tier only)
+
+<Bronze listings can omit Layer 3. Silver listings address each of the seven operational guardrails in the v1.0 spec, briefly, with a link to the public artifact.>
+
+---
+
+## Changelog
+
+- YYYY-MM-DD — Initial publication against v1.0.
+
+---
+
+*Published under CC BY 4.0. The Integrity Framework canonical spec is at https://theintegrityframework.org/framework/v1.*

--- a/src/app/how-to-vet-ai-tools/page.tsx
+++ b/src/app/how-to-vet-ai-tools/page.tsx
@@ -1,0 +1,308 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+
+const PAGE_URL = `${site.url}/how-to-vet-ai-tools`;
+
+export const metadata: Metadata = {
+  title: 'How to vet AI tools when SOC 2 does not apply',
+  description:
+    'A seven-step buyer\u2019s checklist for vetting AI tools at the team or department level, where the product is too small for SOC 2 audits but real money and real data still change hands. Uses INTEGRITY.md and The Integrity Framework directory as the verification surface.',
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: 'How to vet AI tools when SOC 2 does not apply',
+    description:
+      'Seven steps a sub-enterprise buyer can use to vet AI tools without forcing a SOC 2 audit the vendor cannot afford.',
+    type: 'article',
+    url: PAGE_URL,
+    siteName: site.name,
+  },
+};
+
+interface FaqItem { q: string; a: string }
+
+const faqs: FaqItem[] = [
+  {
+    q: 'How do you vet an AI tool that does not have SOC 2?',
+    a: 'For sub-enterprise AI tools \u2014 the segment where SOC 2 audits are too expensive and the wrong shape \u2014 vet on publicly verifiable artifacts: a public INTEGRITY.md self-mapping against The Integrity Framework, a versioned methodology page, a transparent changelog, named operators, and a real privacy policy. The directory at theintegrityframework.org indexes products that have done this, with tier badges buyers can verify themselves.',
+  },
+  {
+    q: 'What is The Integrity Framework?',
+    a: 'A published standard for product trustworthiness aimed at sub-enterprise AI tools where SOC 2 does not apply. Founders self-map their product against six Layer 1 vetoes, post a public INTEGRITY.md, and the directory at theintegrityframework.org publishes them with a Bronze or Silver tier badge. Free and CC BY 4.0.',
+  },
+  {
+    q: 'What red flags should I watch for when vetting an AI tool?',
+    a: 'Five recurring ones: (1) An AI feature with no audit trail or labeling. (2) A pricing page that hides per-seat or per-token math behind \u201Cdemo only\u201D. (3) Marketing claims of \u201Centerprise security\u201D with no SOC 2 or equivalent artifact. (4) A trust page that lists certifications the company does not actually hold. (5) Operators who are anonymous or unreachable. Each of these maps to a Layer 1 veto in The Integrity Framework.',
+  },
+  {
+    q: 'Is INTEGRITY.md a substitute for SOC 2 in my vendor review?',
+    a: 'No. SOC 2 remains the right artifact for service organizations at enterprise spend levels with regulated data flows. INTEGRITY.md is the right artifact for the segment SOC 2 prices out \u2014 $20-$200/month products that one team buys without procurement. Most departmental AI purchases live in that segment, not the SOC 2 segment, and vetting them like SOC 2 vendors produces a quiet failure mode: the team buys anyway, just without any artifact at all.',
+  },
+  {
+    q: 'How long should an AI tool vetting take?',
+    a: 'For a sub-enterprise tool with a published INTEGRITY.md and a listing in the directory: 15-30 minutes. For one without an INTEGRITY.md: it depends on how much surface the buyer needs to assemble themselves \u2014 typically 1-2 hours of reading the privacy policy, the security page, the changelog, and the operator background. The framework exists so that the 1-2 hour assembly job is done once by the vendor, not repeatedly by every buyer.',
+  },
+  {
+    q: 'What if no AI tools in my category have an INTEGRITY.md yet?',
+    a: 'Two practical moves. (1) Ask the vendor: pointing them at theintegrityframework.org and asking when they will publish their INTEGRITY.md is a free signal that you, the buyer, expect this surface. (2) Use the framework yourself as a vetting rubric \u2014 walk the six Layer 1 vetoes against the product\u2019s public artifacts and write the gaps down. The framework is forkable; the rubric works the same way whether the vendor has self-mapped or not.',
+  },
+  {
+    q: 'Where do I report an AI tool that fails the TechCrunch test?',
+    a: 'For products listed in the directory at theintegrityframework.org, listings have a public dispute path on each listing page; quarterly re-scans reflect changes. For unlisted products, the framework spec is CC BY 4.0 and can be cited in your own vendor-review documentation; the directory does not run a global complaint-handling service.',
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((it) => ({
+    '@type': 'Question',
+    name: it.q,
+    acceptedAnswer: { '@type': 'Answer', text: it.a },
+  })),
+};
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to vet AI tools when SOC 2 does not apply',
+  description:
+    'Seven steps for vetting a sub-enterprise AI tool against publicly verifiable artifacts instead of an audit framework that is too expensive for the segment.',
+  inLanguage: 'en-US',
+  totalTime: 'PT30M',
+  step: [
+    { '@type': 'HowToStep', position: 1, name: 'Confirm the product is sub-enterprise', text: 'Check pricing, contract length, and decision-maker. If a single team or department can swipe a card and start, you are in the segment SOC 2 was not built for.' },
+    { '@type': 'HowToStep', position: 2, name: 'Look for an INTEGRITY.md', text: 'Check the repo root, the marketing site, and the trust or security page. A reachable file at a stable URL means the founder has self-mapped against a published standard.' },
+    { '@type': 'HowToStep', position: 3, name: 'Verify the tier badge', text: 'Bronze means six Layer 1 vetoes self-mapped honestly. Silver adds either a green integrity-cli run or a versioned methodology page. Pull the listing from theintegrityframework.org/listings and read both.' },
+    { '@type': 'HowToStep', position: 4, name: 'Walk the six Layer 1 vetoes against the product yourself', text: 'Artifact-vs-outcome, independence, verifiability, AI accountability, pricing-rigor alignment, the TechCrunch test. Five minutes per veto, written in your own notes.' },
+    { '@type': 'HowToStep', position: 5, name: 'Spot-check the linked artifacts', text: 'Click every URL in the INTEGRITY.md. Repos resolve. Methodology pages load. Changelogs have dates. If anything 404s, the verifiability claim is weak.' },
+    { '@type': 'HowToStep', position: 6, name: 'Match pricing to claimed rigor', text: 'Enterprise pricing on self-attested artifacts is a fail. Free pricing on artifacts that imply enterprise rigor is also a fail. The pricing page should be reachable without a demo.' },
+    { '@type': 'HowToStep', position: 7, name: 'Buy or escalate', text: 'If steps 1-6 pass, the tool is vetted to the standard the segment supports. If a Layer 1 veto fails, escalate the specific veto to the vendor in writing and decide based on the response.' },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to vet AI tools when SOC 2 does not apply',
+  description:
+    'A seven-step buyer\u2019s checklist for vetting sub-enterprise AI tools against publicly verifiable artifacts.',
+  author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+  publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+  inLanguage: 'en-US',
+  mainEntityOfPage: PAGE_URL,
+  url: PAGE_URL,
+};
+
+interface Step { n: number; title: string; body: React.ReactNode }
+
+const steps: Step[] = [
+  {
+    n: 1,
+    title: 'Confirm the product is sub-enterprise',
+    body: (
+      <>
+        Pricing under roughly $5K ARR per buyer, contract length under 12 months, decision made
+        by a single team lead or department head. If procurement is not in the room, the SOC 2
+        playbook is the wrong rubric. You are in the segment{' '}
+        <Link href="/framework/v1" className="text-brand-700 underline">
+          The Integrity Framework
+        </Link>{' '}
+        was published for.
+      </>
+    ),
+  },
+  {
+    n: 2,
+    title: 'Look for an INTEGRITY.md',
+    body: (
+      <>
+        Check the repo root, the marketing site at <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">/integrity.md</code>,
+        and the trust or security page. A reachable file at a stable URL means the founder has
+        already done the self-mapping work. See{' '}
+        <Link href="/integrity-md" className="text-brand-700 underline">
+          /integrity-md
+        </Link>{' '}
+        for the format and a worked example.
+      </>
+    ),
+  },
+  {
+    n: 3,
+    title: 'Verify the tier badge',
+    body: (
+      <>
+        Bronze means six Layer 1 vetoes self-mapped honestly. Silver adds either a green{' '}
+        <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">integrity-cli</code> run
+        or a versioned methodology page. Pull the listing from the{' '}
+        <Link href="/listings" className="text-brand-700 underline">
+          directory
+        </Link>{' '}
+        and confirm the artifact links resolve.
+      </>
+    ),
+  },
+  {
+    n: 4,
+    title: 'Walk the six Layer 1 vetoes yourself',
+    body: (
+      <>
+        Even with a published INTEGRITY.md, the buyer\u2019s job is to confirm the self-mapping
+        is honest. Five minutes per veto: artifact-vs-outcome, independence, verifiability, AI
+        accountability, pricing-rigor alignment, the TechCrunch test. Write the gaps in your
+        own notes \u2014 those notes are your audit trail later.
+      </>
+    ),
+  },
+  {
+    n: 5,
+    title: 'Spot-check the linked artifacts',
+    body: (
+      <>
+        Click every URL in the INTEGRITY.md. Repos should resolve. Methodology pages should
+        load with dates on the changelog. If anything 404s, the verifiability claim is weak
+        and the directory should know \u2014 use the listing\u2019s dispute path.
+      </>
+    ),
+  },
+  {
+    n: 6,
+    title: 'Match pricing to claimed rigor',
+    body: (
+      <>
+        Enterprise pricing on a self-attested artifact is a fail (Veto 5). Sub-enterprise
+        pricing on artifacts that imply enterprise rigor is also a fail. The pricing page
+        should be reachable without a demo. Hidden pricing is itself a TechCrunch-test risk.
+      </>
+    ),
+  },
+  {
+    n: 7,
+    title: 'Buy or escalate',
+    body: (
+      <>
+        If steps 1-6 pass, the tool is vetted to the standard this segment supports. If a
+        Layer 1 veto fails, escalate the specific veto to the vendor in writing and decide
+        based on the response. The framework gives you specific language; vague concerns get
+        vague answers.
+      </>
+    ),
+  },
+];
+
+export default function HowToVetAiToolsPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <article className="container-wide py-16 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            Buyer\u2019s guide
+          </p>
+
+          <h1>How to vet AI tools when SOC 2 does not apply</h1>
+
+          {/* Direct-answer paragraph — extractable as a single AI Overview /
+              Perplexity citation block. ~60 words, named entity in first
+              sentence, definition before context. */}
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+            <strong>To vet an AI tool that does not have SOC 2</strong>, vet on publicly
+            verifiable artifacts: a public{' '}
+            <Link href="/integrity-md" className="text-brand-700 underline">
+              INTEGRITY.md
+            </Link>{' '}
+            self-mapping against{' '}
+            <Link href="/framework/v1" className="text-brand-700 underline">
+              The Integrity Framework
+            </Link>
+            , a versioned methodology page, a transparent changelog, named operators, and a
+            real privacy policy. The directory at theintegrityframework.org indexes products
+            that have done this with tier badges you can verify yourself. The seven steps
+            below take about 30 minutes per tool.
+          </p>
+
+          <h2 className="mt-12">The seven steps</h2>
+          <ol className="mt-6 space-y-6">
+            {steps.map((s) => (
+              <li key={s.n} className="grid grid-cols-[2rem_1fr] gap-4">
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-700 text-sm font-semibold text-white">
+                  {s.n}
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-surface-900">{s.title}</h3>
+                  <p className="mt-2 text-surface-700 leading-relaxed">{s.body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <h2 className="mt-12">Red flags that cost a buyer six months</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-3 text-surface-700">
+            <li><strong>An AI feature with no audit trail or labeling.</strong> If the product
+              writes decisions, summaries, or recommendations on behalf of the buyer and there
+              is no way to inspect what it did, Veto 4 fails.</li>
+            <li><strong>&ldquo;Enterprise security&rdquo; with no SOC 2 link.</strong> The
+              phrase without the artifact is a Veto 1 fail \u2014 selling the artifact (security)
+              without delivering it.</li>
+            <li><strong>Hidden pricing.</strong> &ldquo;Contact us&rdquo; on a $20-200/month
+              product is a Veto 5 mismatch unless every customer is on a custom contract,
+              which the segment economics make implausible.</li>
+            <li><strong>A trust page that lists certifications the company does not actually
+              hold.</strong> Veto 6 territory. Cross-check every named certification against
+              the issuing body\u2019s public directory.</li>
+            <li><strong>Anonymous or unreachable operators.</strong> An LLC with no named
+              principal, no LinkedIn, and no contact path is a Veto 2 fail by default.</li>
+          </ul>
+
+          <h2 className="mt-12">If no tools in the category are listed yet</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Two moves. First, ask the vendor: pointing them at theintegrityframework.org and
+            asking when they will publish their INTEGRITY.md is a free signal that you, the
+            buyer, expect this surface. Vendors who care about trust will write one; vendors
+            who do not, will not, and that is also useful information.
+          </p>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Second, use the framework as a vetting rubric yourself. Walk the six Layer 1 vetoes
+            against the product\u2019s public artifacts and write the gaps down. The framework
+            is forkable under CC BY 4.0; the rubric works the same way whether the vendor has
+            self-mapped or not.
+          </p>
+
+          <h2 className="mt-12">Frequently asked questions</h2>
+          <dl className="mt-4 space-y-6">
+            {faqs.map((it) => (
+              <div key={it.q}>
+                <dt className="font-semibold text-surface-900">{it.q}</dt>
+                <dd className="mt-2 text-surface-700 leading-relaxed">{it.a}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="mt-12 flex flex-wrap gap-3">
+            <Link
+              href="/listings"
+              className="inline-flex items-center rounded-md bg-brand-700 px-5 py-3 text-sm font-medium text-white no-underline hover:bg-brand-800"
+            >
+              Browse the directory
+            </Link>
+            <Link
+              href="/framework/v1"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              Read the framework spec
+            </Link>
+            <Link
+              href="/integrity-md"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              INTEGRITY.md template
+            </Link>
+          </div>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/integrity-framework-vs-coso/page.tsx
+++ b/src/app/integrity-framework-vs-coso/page.tsx
@@ -143,6 +143,23 @@ export default function IntegrityFrameworkVsCosoPage() {
             If you arrived here looking for one and found the other, this page is the map.
           </p>
 
+          {/* Reverse-anchor block — same answer phrased for the "COSO vs
+              Integrity Framework" query direction. Same content, different
+              query-intent surface. */}
+          <h2 id="coso-vs-the-integrity-framework" className="mt-12">COSO vs The Integrity Framework</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            <strong>COSO vs The Integrity Framework</strong> is the same disambiguation viewed
+            from the other direction. COSO\u2019s Internal Control - Integrated Framework
+            (published 1992, updated 2013, by the Committee of Sponsoring Organizations of the
+            Treadway Commission) is the standard public companies and audit firms use for SOX
+            financial-reporting controls. The Integrity Framework (published 2026 by Startvest
+            LLC, CC BY 4.0) is a standard for sub-enterprise AI-product trustworthiness with a
+            public directory and tier badges. A buyer choosing between them is almost always
+            choosing between segments, not frameworks \u2014 if the buyer is a public-company
+            audit team, COSO; if the buyer is a team-or-department AI tool purchaser, The
+            Integrity Framework. They are not direct alternatives.
+          </p>
+
           <h2 className="mt-12">Why this page exists</h2>
           <p className="mt-3 text-surface-700 leading-relaxed">
             Search engines and AI engines confuse the two. Perplexity, ChatGPT, and Google AI

--- a/src/app/integrity-md/page.tsx
+++ b/src/app/integrity-md/page.tsx
@@ -1,0 +1,302 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+
+const PAGE_URL = `${site.url}/integrity-md`;
+
+export const metadata: Metadata = {
+  title: 'INTEGRITY.md — Template, format, and worked example',
+  description:
+    'INTEGRITY.md is a public, founder-authored file at the root of an AI product that self-maps the product against The Integrity Framework. Free CC BY 4.0 template, worked example, and the verification rules the directory applies.',
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: 'INTEGRITY.md template + format',
+    description:
+      'Free CC BY 4.0 template for the public trust artifact The Integrity Framework Bronze tier requires.',
+    type: 'article',
+    url: PAGE_URL,
+    siteName: site.name,
+  },
+};
+
+interface FaqItem { q: string; a: string }
+
+const faqs: FaqItem[] = [
+  {
+    q: 'What is INTEGRITY.md?',
+    a: 'INTEGRITY.md is a public, founder-authored markdown file at the root of an AI product\u2019s repository or website that self-maps the product against The Integrity Framework. It addresses each of the six Layer 1 vetoes by name, names the product\u2019s framework version, and is required for the Bronze tier in the directory at theintegrityframework.org.',
+  },
+  {
+    q: 'Where should INTEGRITY.md live?',
+    a: 'At the canonical product surface a buyer would find first. For open-source AI tools, that is the repo root next to README.md. For closed-source SaaS, that is the marketing site at /integrity.md or linked from the trust or security page. The file must be reachable without authentication.',
+  },
+  {
+    q: 'Do I need to use Markdown?',
+    a: 'Markdown is the conventional format and what the directory verifier expects. HTML or plaintext work if the headings and section labels match the template. The verifier reads the document structurally; format flexibility is OK as long as each Layer 1 veto is addressed under a clearly labeled section.',
+  },
+  {
+    q: 'How long should INTEGRITY.md be?',
+    a: 'Long enough to be honest about each veto, short enough to read in 10 minutes. TIF\u2019s own INTEGRITY.md (for the directory itself) is roughly 100 lines of markdown. Listings on the directory range from 60 to 300 lines depending on how much disclosure the product surface area requires. Brevity that conceals trade-offs fails verification; verbosity that pads sections does too.',
+  },
+  {
+    q: 'What if my product fails a veto?',
+    a: 'Name the failure in the section, in plain language, with the trade-off you accept. The framework names \u201Carchitectural honesty\u201D as a passing condition for several vetoes \u2014 a disclosed failure beats a cosmetic pass. The directory will list a product with a disclosed failure at Bronze; it will reject a product that pretends to pass when it does not.',
+  },
+  {
+    q: 'How does the directory verify INTEGRITY.md?',
+    a: 'The Startvest team reads the file, checks the public artifacts it references (repo links, methodology page, integrity-cli output, etc.), and matches the self-mapping against the v1.0 spec at /framework/v1. Listings re-scan quarterly. A spec version bump triggers re-verification; a removed or hidden INTEGRITY.md downgrades or de-lists the product.',
+  },
+  {
+    q: 'Is INTEGRITY.md a substitute for SOC 2?',
+    a: 'No. SOC 2 is an audited control report for service organizations at enterprise spend levels. INTEGRITY.md is a self-mapped, publicly verifiable trust artifact for the sub-enterprise segment where SOC 2 is the wrong shape. Products that legitimately need SOC 2 should still pursue it. INTEGRITY.md addresses the segment SOC 2 prices out.',
+  },
+  {
+    q: 'Can I fork the template?',
+    a: 'Yes. The Integrity Framework spec is CC BY 4.0. The INTEGRITY.md template here is CC BY 4.0 as well. Fork for your own segment if the six Layer 1 vetoes do not fit your product shape; the directory at theintegrityframework.org indexes products that self-map against the canonical Startvest version.',
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((it) => ({
+    '@type': 'Question',
+    name: it.q,
+    acceptedAnswer: { '@type': 'Answer', text: it.a },
+  })),
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'INTEGRITY.md \u2014 Template, format, and worked example',
+  description:
+    'Free CC BY 4.0 template for the INTEGRITY.md trust artifact required by The Integrity Framework Bronze tier.',
+  author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+  publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+  inLanguage: 'en-US',
+  mainEntityOfPage: PAGE_URL,
+  url: PAGE_URL,
+  license: 'https://creativecommons.org/licenses/by/4.0/',
+  about: {
+    '@type': 'DefinedTerm',
+    name: 'INTEGRITY.md',
+    description:
+      'A public, founder-authored file at the root of an AI product that self-maps the product against The Integrity Framework v1.0.',
+    inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+    termCode: 'integrity-md',
+  },
+};
+
+const TEMPLATE = `# INTEGRITY.md \u2014 <Product name>
+
+**Product:** <Product name> (<canonical-url>)
+**Operator:** <Legal entity>
+**Framework version evaluated against:** 1.0
+**Self-evaluation tier:** Bronze | Silver
+**Last updated:** YYYY-MM-DD
+
+<One- or two-sentence honest description of what the product is and who it is for. The directory verifier reads this to confirm the product surface matches the rest of the file.>
+
+---
+
+## Layer 1 vetoes \u2014 self-mapping
+
+### Veto 1 \u2014 Artifact versus outcome
+
+**Pass | Fail with disclosed trade-off.**
+
+<Explain whether the product sells the artifact (a certification, a badge, a report) or the outcome the artifact is supposed to indicate. Name any cases where the line is fuzzy. Disclosed fuzziness beats a cosmetic pass.>
+
+### Veto 2 \u2014 Independence
+
+**Pass | Pass with disclosed conflict | Fail with disclosed trade-off.**
+
+<Disclose every relationship between the product, its operators, its listed customers, and any party that benefits from a favorable rating. Material conflicts must be named on the listing surface, not just here.>
+
+### Veto 3 \u2014 Verifiability
+
+**Pass | Fail with disclosed trade-off.**
+
+<List the artifacts a third-party reader can verify mechanically: public repo, changelog with versioned methodology page, integrity-cli output, signed receipts, anything else. Anything not externally verifiable should be marked as such.>
+
+### Veto 4 \u2014 AI accountability
+
+**Pass | Fail with disclosed trade-off.**
+
+<Describe what the product does and does not do with AI. Where AI generates artifacts (text, decisions, recommendations) the failure mode is hidden generation; pass requires labeling, audit trail, or a human-in-the-loop pattern surfaced to the buyer.>
+
+### Veto 5 \u2014 Pricing-rigor alignment
+
+**Pass | Fail with disclosed trade-off.**
+
+<State whether the product\u2019s pricing matches the rigor of the artifact it sells. Enterprise pricing on a self-attested artifact is a fail. Free or sub-enterprise pricing on artifacts that imply enterprise rigor is also a fail. Mismatch should be named.>
+
+### Veto 6 \u2014 The TechCrunch test
+
+**Pass | Fail with disclosed trade-off.**
+
+<Imagine the headline if your worst failure mode were reported publicly tomorrow. If a journalist would describe the product as misleading, deceptive, or theatrical based on this INTEGRITY.md, it does not pass.>
+
+---
+
+## Layer 2 constraints (Silver tier only)
+
+<Bronze listings can omit Layer 2. Silver listings address each of the seven architectural constraints in the v1.0 spec, briefly, with a link to the public artifact that demonstrates conformance.>
+
+---
+
+## Layer 3 guardrails (Silver tier only)
+
+<Bronze listings can omit Layer 3. Silver listings address each of the seven operational guardrails in the v1.0 spec, briefly, with a link to the public artifact.>
+
+---
+
+## Changelog
+
+- YYYY-MM-DD \u2014 Initial publication against v1.0.
+
+---
+
+*Published under CC BY 4.0. The Integrity Framework canonical spec is at https://theintegrityframework.org/framework/v1.*
+`;
+
+export default function IntegrityMdPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <article className="container-wide py-16 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            Trust artifact \u00B7 CC BY 4.0
+          </p>
+
+          <h1>INTEGRITY.md</h1>
+
+          {/* Direct-answer paragraph — extractable as a single AI Overview /
+              Perplexity citation block. ~60 words, named entity in first
+              sentence, definition before context. */}
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+            <strong>INTEGRITY.md</strong> is a public, founder-authored file at the root of an
+            AI product\u2019s repository or website that self-maps the product against{' '}
+            <Link href="/framework/v1" className="text-brand-700 underline">
+              The Integrity Framework v1.0
+            </Link>
+            . It addresses each of the six Layer 1 vetoes by name, names the product\u2019s
+            framework version, and is required for the Bronze tier in the directory at
+            theintegrityframework.org. The format is plain Markdown. The license is CC BY 4.0.
+            A worked example is the file at the root of this site\u2019s own repo.
+          </p>
+
+          <h2 className="mt-12">The template</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Copy this into <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">INTEGRITY.md</code>{' '}
+            at your product\u2019s canonical surface (repo root for open source, marketing site
+            for closed-source SaaS). Replace every angle-bracket placeholder. Do not delete
+            sections \u2014 if a veto does not apply, name the trade-off in plain language.
+          </p>
+
+          <div className="mt-6 rounded-lg border border-surface-200 bg-surface-50 overflow-hidden">
+            <div className="flex items-center justify-between border-b border-surface-200 bg-white px-4 py-2 text-xs text-surface-600">
+              <span className="font-mono">INTEGRITY.md</span>
+              <a
+                href="/templates/INTEGRITY.template.md"
+                download
+                className="text-brand-700 underline"
+              >
+                Download
+              </a>
+            </div>
+            <pre className="overflow-x-auto p-4 text-xs leading-relaxed text-surface-800 whitespace-pre-wrap">
+              {TEMPLATE}
+            </pre>
+          </div>
+
+          <h2 className="mt-12">Worked example</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            The Integrity Framework Directory is itself a product, evaluated against the
+            framework it publishes. Its INTEGRITY.md is the canonical worked example. It is
+            written from the operator\u2019s point of view, names a real conflict of interest
+            under Veto 2, and discloses the path to lifting that conflict over time.
+          </p>
+          <p className="mt-3">
+            <a
+              href="https://github.com/Startvest-LLC/theintegrityframework/blob/master/INTEGRITY.md"
+              className="text-brand-700 underline"
+              rel="noopener"
+            >
+              Read the directory\u2019s INTEGRITY.md on GitHub \u2192
+            </a>
+          </p>
+
+          <h2 className="mt-12">Verification</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            When a listing is submitted, the directory verifier reads INTEGRITY.md and
+            confirms:
+          </p>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>The file is reachable at a stable, unauthenticated URL.</li>
+            <li>Each of the six Layer 1 vetoes is addressed under a clearly labeled section.</li>
+            <li>The product\u2019s framework version is named explicitly (e.g. <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">1.0</code>).</li>
+            <li>The artifacts the file references (repo URLs, methodology pages, integrity-cli output) actually exist and resolve.</li>
+            <li>The self-mapping passes the TechCrunch test in Veto 6.</li>
+          </ul>
+          <p className="mt-4 text-surface-700 leading-relaxed">
+            Silver listings additionally need either a passing{' '}
+            <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">integrity-cli</code>{' '}
+            run against the public repo, or a versioned public methodology page. A failing
+            verification returns to the submitter with the specific veto or artifact at issue.
+          </p>
+
+          <h2 className="mt-12">Common mistakes</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li><strong>Marking every veto Pass with no trade-off.</strong> Real products carry
+              trade-offs. A spotless self-mapping is a TechCrunch-test fail by itself.</li>
+            <li><strong>Linking artifacts that require auth.</strong> If a buyer cannot read the
+              referenced doc without an NDA, the artifact does not count toward Verifiability.</li>
+            <li><strong>Vague AI accountability copy.</strong> &ldquo;We use AI responsibly&rdquo;
+              is not a pass. Name what the AI generates, what the audit trail is, and what the
+              human checkpoint is.</li>
+            <li><strong>Skipping Layer 2 / Layer 3 on a Silver submission.</strong> The directory
+              cannot self-promote a listing past Bronze without those sections.</li>
+            <li><strong>Forgetting to update on framework version bumps.</strong> If the spec moves
+              to 1.1, the file must be re-mapped or downgraded to Bronze of the old spec version.</li>
+          </ul>
+
+          <h2 className="mt-12">Frequently asked questions</h2>
+          <dl className="mt-4 space-y-6">
+            {faqs.map((it) => (
+              <div key={it.q}>
+                <dt className="font-semibold text-surface-900">{it.q}</dt>
+                <dd className="mt-2 text-surface-700 leading-relaxed">{it.a}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="mt-12 flex flex-wrap gap-3">
+            <Link
+              href="/framework/v1"
+              className="inline-flex items-center rounded-md bg-brand-700 px-5 py-3 text-sm font-medium text-white no-underline hover:bg-brand-800"
+            >
+              Read the framework spec
+            </Link>
+            <Link
+              href="/submit"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              Submit a listing
+            </Link>
+            <Link
+              href="/listings"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              Browse the directory
+            </Link>
+          </div>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,6 +24,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/what-is-the-integrity-framework`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/integrity-framework-vs-coso`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/implement-integrity-framework-90-days`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${base}/integrity-md`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${base}/how-to-vet-ai-tools`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
     { url: `${base}/methodology`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/changelog`, lastModified, changeFrequency: 'weekly', priority: 0.6 },
     { url: `${base}/submit`, lastModified, changeFrequency: 'monthly', priority: 0.6 },


### PR DESCRIPTION
## What

AEO Ownership Plan Sprint 1 deliverables — own the \"INTEGRITY.md\" and \"how to vet AI tools\" categories on Perplexity / ChatGPT / Google AI Overview. See the plan at `idealift/docs/AEO-OWNERSHIP-PLAN.md` (PR Startvest-LLC/idealift#2614).

### Three pages

1. **`/integrity-md`** — the canonical landing page for the trust artifact The Integrity Framework Bronze tier requires. Direct-answer paragraph for AIO citation, full template inline as a copyable block, download link to `/templates/INTEGRITY.template.md`, worked-example link to this repo's own INTEGRITY.md, verification rules, common-mistakes section, 8-question FAQ. Schema: Article + FAQPage + DefinedTerm.

2. **`/how-to-vet-ai-tools`** — buyer-side seven-step guide. Positions The Integrity Framework + INTEGRITY.md as the verification surface for sub-enterprise AI tools where SOC 2 doesn't apply. Schema: HowTo + Article + FAQPage. Red-flags section, fallback strategy when no tools in the category are listed yet.

3. **`/integrity-framework-vs-coso`** — added a reverse-anchor section `COSO vs The Integrity Framework` with `id=\"coso-vs-the-integrity-framework\"` so the same disambiguation lives on the same URL from both query directions.

### Targets

| Page | Target queries |
|---|---|
| /integrity-md | \"integrity.md template\", \"how to write integrity md\", \"integrity.md example\", \"integrity md format\" |
| /how-to-vet-ai-tools | \"how to vet ai tools\", \"ai vendor trust without soc 2\", \"buyer-vetting ai\", \"buying ai tools without soc 2\" |
| /integrity-framework-vs-coso (reverse-anchor) | \"coso vs integrity framework\", \"coso alternative for ai tools\", \"coso framework alternative\", \"coso for indie founders\" |

### Files

- `src/app/integrity-md/page.tsx` — new
- `src/app/how-to-vet-ai-tools/page.tsx` — new
- `src/app/integrity-framework-vs-coso/page.tsx` — reverse-anchor section added
- `public/templates/INTEGRITY.template.md` — new (the actual downloadable template)
- `src/app/sitemap.ts` — two new entries

### Verification post-deploy

```bash
# Direct-answer paragraphs present as Googlebot
curl -s -A Googlebot https://theintegrityframework.org/integrity-md | grep -oE 'INTEGRITY.md[^<]{0,80}' | head -1
curl -s -A Googlebot https://theintegrityframework.org/how-to-vet-ai-tools | grep -oE 'To vet an AI tool[^<]{0,80}' | head -1
curl -s https://theintegrityframework.org/integrity-framework-vs-coso | grep -oE 'COSO vs The Integrity Framework' | head -1

# Schema valid in Google's Rich Results Test
# https://search.google.com/test/rich-results?url=https%3A%2F%2Ftheintegrityframework.org%2Fintegrity-md
# https://search.google.com/test/rich-results?url=https%3A%2F%2Ftheintegrityframework.org%2Fhow-to-vet-ai-tools

# Template download resolves
curl -sI https://theintegrityframework.org/templates/INTEGRITY.template.md | head -3
```

### Citation push (Sprint 1 follow-up, not in this PR)

Per the plan: HN post (\"We open-sourced a compliance framework for sub-enterprise SaaS\"), Reddit r/SaaS and r/cybersecurity, Indie Hackers feature, draft INTEGRITY.md format as an RFC/ECMA-style spec. Tracking those manually rather than as PR work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)