### PR TITLE
feat(aeo): machine-readable /framework/v1.json JSON-LD spec

### DIFF
--- a/src/app/framework/v1.json/route.ts
+++ b/src/app/framework/v1.json/route.ts
@@ -1,0 +1,151 @@
+/**
+ * Machine-readable JSON-LD representation of The Integrity Framework v1.0.
+ *
+ * LLM crawlers and citation engines preferentially index structured data
+ * over rendered HTML. Exposing the framework as a single, schema.org-typed
+ * JSON document at a stable URL gives them something concrete to extract.
+ *
+ * License: CC BY 4.0 — same as the prose spec at /framework/v1.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+const FRAMEWORK_URL = 'https://theintegrityframework.org/framework/v1';
+const JSON_URL = 'https://theintegrityframework.org/framework/v1.json';
+const LICENSE_URL = 'https://creativecommons.org/licenses/by/4.0/';
+const PUBLISHER = {
+  '@type': 'Organization',
+  name: 'Startvest LLC',
+  url: 'https://startvest.ai',
+};
+
+const LAYER_1_VETOES = [
+  {
+    code: 'V1',
+    name: 'Artifact versus outcome',
+    description:
+      'A product passes if it sells the outcome (actual compliance, security, audit-readiness). It fails if it sells the artifact (a report, badge, or score) divorced from the outcome it implies.',
+  },
+  {
+    code: 'V2',
+    name: 'Independence',
+    description:
+      'A product passes if the customer pays for tooling that helps them prepare for verification by genuinely independent third parties. It fails if the same vendor is paid both to prepare and to certify.',
+  },
+  {
+    code: 'V3',
+    name: 'Verifiability',
+    description:
+      'A product passes if a third-party reader can mechanically verify what is claimed. It fails if customer attestation alone is offered as proof.',
+  },
+  {
+    code: 'V4',
+    name: 'AI accountability',
+    description:
+      'A product passes if AI outputs pass through documented review gates before becoming customer-facing attestations. It fails if AI goes directly to attestation with no human checkpoint or labeling.',
+  },
+  {
+    code: 'V5',
+    name: 'Pricing-rigor alignment',
+    description:
+      'A product passes if pricing is tied to the actual work performed. It fails if pricing creates financial pressure to skip work (e.g., "unlimited audits" at a flat rate).',
+  },
+  {
+    code: 'V6',
+    name: 'The TechCrunch test',
+    description:
+      'A product passes if the worst plausible headline in 18 months can be defended with concrete methodology. It fails if the defense would require hand-waving.',
+  },
+];
+
+const TIERS = [
+  {
+    name: 'Bronze',
+    description:
+      'A public INTEGRITY.md at the repo or product website that addresses all six Layer 1 vetoes by name. The most common entry tier.',
+  },
+  {
+    name: 'Silver',
+    description:
+      'Bronze plus one of: a green integrity-cli run against the public repo, or a public methodology page with a versioned changelog.',
+  },
+];
+
+function buildPayload() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    '@id': FRAMEWORK_URL,
+    identifier: 'integrity-framework',
+    name: 'The Integrity Framework',
+    alternateName: ['Integrity Framework', 'Startvest Integrity Framework'],
+    description:
+      'A published standard for product trustworthiness aimed at sub-enterprise AI tools, the segment where SOC 2 audits do not apply. Founders self-map their product against six pre-build vetoes, post a public INTEGRITY.md, and the directory at theintegrityframework.org publishes them with a Bronze or Silver tier badge.',
+    inLanguage: 'en-US',
+    license: LICENSE_URL,
+    url: FRAMEWORK_URL,
+    sameAs: [FRAMEWORK_URL, JSON_URL],
+    publisher: PUBLISHER,
+    creator: PUBLISHER,
+    dateCreated: '2026-04-25',
+    dateModified: '2026-04-25',
+    version: '1.0',
+    inDefinedTermSet: {
+      '@type': 'DefinedTermSet',
+      name: 'The Integrity Framework v1.0',
+      url: FRAMEWORK_URL,
+      hasDefinedTerm: LAYER_1_VETOES.map((v) => ({
+        '@type': 'DefinedTerm',
+        identifier: v.code,
+        name: v.name,
+        description: v.description,
+        inDefinedTermSet: FRAMEWORK_URL,
+      })),
+    },
+    audience: {
+      '@type': 'Audience',
+      audienceType:
+        'Founders building sub-enterprise AI tools, and buyers vetting AI tools at the team or department level.',
+    },
+    // Non-standard but useful extensions for LLM consumers — kept under
+    // a vendor-prefixed namespace so schema.org parsers ignore them.
+    'tif:tiers': TIERS,
+    'tif:layers': [
+      {
+        name: 'Layer 1: Pre-build vetoes',
+        description: 'Six questions evaluated before a product gets built or before a major scope expansion. Wrong answer kills the product, not delays it.',
+        items: LAYER_1_VETOES,
+      },
+      {
+        name: 'Layer 2: Architectural constraints',
+        description: 'Seven constraints baked into every Silver-tier product, CI-enforced where possible. Listed in the prose spec at /framework/v1#layer-2.',
+      },
+      {
+        name: 'Layer 3: Operational guardrails',
+        description: 'Seven operational practices required for Silver-tier listings. Listed in the prose spec at /framework/v1#layer-3.',
+      },
+    ],
+    'tif:integrityMdTemplate': 'https://theintegrityframework.org/integrity-md',
+    'tif:directory': 'https://theintegrityframework.org/listings',
+  };
+}
+
+export async function GET() {
+  const payload = buildPayload();
+  return NextResponse.json(payload, {
+    headers: {
+      // JSON-LD content type so crawlers that special-case structured data
+      // pick it up immediately. Plain application/json works too — the LD
+      // form is just more discoverable.
+      'Content-Type': 'application/ld+json',
+      // Long cache — the spec doesn't change without a version bump.
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      // CORS open so external aggregators (citation engines, awesome-list
+      // generators, AI-vendor scrapers) can fetch without preflight pain.
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/src/app/framework/v1/page.tsx
+++ b/src/app/framework/v1/page.tsx
@@ -11,7 +11,12 @@ export const metadata: Metadata = {
   title: 'The Integrity Framework v1.0',
   description:
     'The Integrity Framework v1.0. Frozen canonical spec. Three operational layers, eight moat layers, six buyer questions. Originated by Startvest LLC. Published under CC BY 4.0. Hosted on the framework\'s neutral domain.',
-  alternates: { canonical: '/framework/v1' },
+  alternates: {
+    canonical: '/framework/v1',
+    // Crawlers and LLM aggregators that prefer structured data over rendered
+    // HTML can fetch the same spec as a single JSON-LD document.
+    types: { 'application/ld+json': '/framework/v1.json' },
+  },
   openGraph: {
     title: 'The Integrity Framework v1.0',
     description:

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,6 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/listings`, lastModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${base}/framework`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/framework/v1`, lastModified, changeFrequency: 'yearly', priority: 0.95 },
+    { url: `${base}/framework/v1.json`, lastModified, changeFrequency: 'yearly', priority: 0.85 },
     { url: `${base}/framework/why`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
     { url: `${base}/framework/audit-log`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
     { url: `${base}/framework/cases`, lastModified, changeFrequency: 'monthly', priority: 0.85 },


### PR DESCRIPTION
Item 10 of the AEO distribution plan (`idealift/docs/AEO-DISTRIBUTION-WEEK-2026-05-18.md`). LLM crawlers and citation engines preferentially index structured data over rendered HTML. Exposing the framework at a stable JSON-LD URL gives them something concrete to extract.

## Changes

- **`src/app/framework/v1.json/route.ts`** — new route handler emitting JSON-LD with `Content-Type: application/ld+json`, CORS open, cached 1h browser / 24h CDN, `force-static` so no runtime cost.
- Payload uses schema.org `DefinedTerm` at the root with `inDefinedTermSet` enumerating the six Layer 1 vetoes (V1-V6) as nested `DefinedTerm` entries, each with identifier / name / description.
- Vendor-prefixed extensions (`tif:tiers`, `tif:layers`, `tif:integrityMdTemplate`, `tif:directory`) so LLM consumers that want the full picture can see it; schema.org parsers ignore them.
- **`src/app/framework/v1/page.tsx`** — Metadata.alternates.types now declares the JSON as alternate, surfacing it via `<link rel=alternate type=application/ld+json>` on the HTML page.
- **`src/app/sitemap.ts`** — new sitemap entry.

## Verify post-deploy

```bash
curl -sI https://theintegrityframework.org/framework/v1.json | head -5
curl -s https://theintegrityframework.org/framework/v1.json | jq '."@type", .name, .version, (.inDefinedTermSet.hasDefinedTerm | length)'
# Expected: "DefinedTerm", "The Integrity Framework", "1.0", 6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)