### PR TITLE
adoption: how-to-write-an-integrity-md + prospect tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ next-env.d.ts
 # Re-scan reports (CI artifacts, not source)
 rescan-report.json
 rescan-report.md
+
+# Local-only notes alongside public dev-tools (named prospects, etc.)
+dev-tools/*.local.md
+dev-tools/*.local.json

--- a/dev-tools/outreach-templates.md
+++ b/dev-tools/outreach-templates.md
@@ -1,0 +1,176 @@
+# Outreach templates — directory submissions
+
+Cold-email / contact-form templates for inviting non-Startvest products into
+the directory. Targets come from `prospect-listings.mjs` output.
+
+**Send from:** `integrity@startvest.ai` (already wired as the directory contact)
+**Medium:** product website contact form or founder email if discoverable on
+the site. No LinkedIn outreach — see prior decision.
+**Volume cap:** ~5–7 per week. The credibility signal is the directory's
+restraint, not its blast radius.
+
+Honest framing rules across all tiers:
+
+- Lead with the specific thing you read on their site. Anything generic reads
+  as blast and goes straight to spam.
+- Disclose state honestly: how many listings live, that all current ones are
+  Startvest's own under COI disclosure, framework is CC BY 4.0, that the
+  recipient would be among the first non-operator listings.
+- Soft ask. Don't push for "yes today" — point to the half-day walkthrough
+  and let the founder self-qualify.
+- No urgency manufactured. No "we're filling spots fast."
+- Sign-off includes the directory URL and your name. Short signature.
+
+The named-prospect worked examples and per-prospect hook lines live in a
+local-only file (`outreach-templates.local.md`, gitignored). Keep this file
+to the reusable scaffolding.
+
+---
+
+## Tier A — already publish a trust artifact
+
+These founders have either an INTEGRITY.md, a /trust page, /methodology, or
+/security page on their product site. The pitch is "you're 80% there." Aim:
+under 130 words.
+
+### Template
+
+```
+Subject: Saw your <ARTIFACT> — quick directory question
+
+<NAME>,
+
+<HOOK — one specific sentence proving I read their thing. Reference the file
+or page by name, and one detail from it that struck me.>
+
+I run theintegrityframework.org — a public directory of products evaluated
+against the Integrity Framework, a standard for sub-enterprise AI tools where
+SOC 2 doesn't apply. Two tiers, Bronze and Silver, both based on public
+artifacts buyers can verify themselves. Listing is free, no paid tier exists.
+
+Looking at <THEIR PAGE>, you're already past the Bronze gate or close to it.
+Half a day of restructuring against the six Layer 1 vetoes would qualify
+you for a listing: https://theintegrityframework.org/how-to-write-an-integrity-md
+
+Honest state: <N> listings live, all Startvest's own with COI disclosure (we
+operate the directory and list our own products under the same rubric). The
+first non-Startvest listings go live alongside the public launch — your
+product would be among them.
+
+If it's a fit, the form is at https://theintegrityframework.org/submit/form.
+If not, no follow-up.
+
+<SIGN-OFF>
+Tom Pinder
+Startvest LLC
+https://theintegrityframework.org
+```
+
+### How to write the hook line
+
+Quote the specific artifact and one detail from it. Bad hook: "Saw you care
+about trust." Good hook: "Your /security page's threat-model table reads
+like the Verifiability veto in product form." Specificity proves the email
+isn't blast.
+
+---
+
+## Tier B — solid segment fit, no trust artifact yet
+
+These products are clearly in segment but haven't shipped a trust page or
+INTEGRITY.md. The pitch is "you'd be a fit; here's how it works." Aim: under
+130 words.
+
+### Template
+
+```
+Subject: <PRODUCT> — quick question on AI trust signals
+
+<NAME>,
+
+<HOOK — one specific sentence proving I read their thing.>
+
+I run theintegrityframework.org — a public directory of products evaluated
+against a free, forkable trust framework for sub-enterprise AI tools. Two
+tiers, Bronze and Silver, both based on public artifacts buyers can verify
+themselves. No paid tier.
+
+The Bronze tier just needs a public INTEGRITY.md mapping six pre-build vetoes
+on your repo or site. Half-day walkthrough with a copy-paste template:
+https://theintegrityframework.org/how-to-write-an-integrity-md
+
+Honest state: <N> listings live, all Startvest's own with COI disclosure.
+First non-Startvest listings go live alongside the public launch.
+
+No follow-up if not a fit.
+
+Tom Pinder
+Startvest LLC
+https://theintegrityframework.org
+```
+
+### How to write the hook line
+
+Pick the one framework veto the product implicitly satisfies (or implicitly
+fails). Tie the hook to that veto by name. Example shape: "An AI tool that
+touches a customer's codebase is the canonical case for the framework's AI
+accountability veto." Keep it under 20 words.
+
+---
+
+## Tier C — cold, compliance-shaped products
+
+These are AI products in regulated/compliance-adjacent segments without any
+trust artifact yet. Soft ask. Lower expected conversion. Aim: under 110
+words.
+
+### Template
+
+```
+Subject: A trust framework for products like <PRODUCT>
+
+<NAME>,
+
+<HOOK — one sentence on what they do.>
+
+If you're thinking about how buyers vet AI tools in regulated segments, the
+Integrity Framework was written for that gap. It's a free, forkable standard
+with a public directory at theintegrityframework.org. Sub-enterprise AI,
+where SOC 2 doesn't fit. Listing is free, no paid tier.
+
+Worth a 5-minute read if buyer trust is a recurring objection in your sales:
+https://theintegrityframework.org/what-is-the-integrity-framework
+
+Half-day walkthrough if you want the full path to a Bronze listing:
+https://theintegrityframework.org/how-to-write-an-integrity-md
+
+No follow-up if not a fit.
+
+Tom Pinder · Startvest LLC · https://theintegrityframework.org
+```
+
+### How to write the hook line
+
+A single descriptive sentence — what the product does and which segment it
+serves. No editorial. The point is to prove the email isn't a bulk send;
+the framework pitch carries the rest. Tier C conversion is low; treat it
+as seed planting, not active outreach.
+
+---
+
+## What to track
+
+After each batch, track in a local-only spreadsheet (not committed):
+
+| Date | Recipient | Tier | Sent via | Response | Outcome |
+|---|---|---|---|---|---|
+
+The conversion rate matters less than which *kind* of hook is converting.
+After the first 15 sends, look for patterns: did Tier A convert better than
+Tier C as expected, or did the cold compliance-shaped Tier C cluster respond
+better because they have a more acute buyer-trust pain point? Adjust the
+mix.
+
+The first non-Startvest listing is the credibility moment. Don't push for
+volume; push for one approval that lets the public launch run with a real
+mixed-portfolio directory.

--- a/dev-tools/prospect-listings.mjs
+++ b/dev-tools/prospect-listings.mjs
@@ -282,7 +282,11 @@ function rankWithin(tier, p) {
 }
 
 function mdEscape(s) {
-  return String(s ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+  return String(s ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ')
+    .trim();
 }
 
 function buildReport(byTier, generatedAt) {

--- a/dev-tools/prospect-listings.mjs
+++ b/dev-tools/prospect-listings.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+//
+// prospect-listings.mjs
+//
+// Find directory-listing candidates for direct outreach by hitting public
+// APIs that pre-filter for "founder who already publishes trust artifacts."
+//
+// Sources (all public / sanctioned):
+//   - GitHub code search via `gh api search/code` (auth via gh CLI)
+//       Files: INTEGRITY.md, TRUST.md, RESPONSIBLE-AI.md, AI-POLICY.md
+//   - HN Algolia API (no auth) for recent "Show HN" / "Launch HN" launches
+//   - Domain probe (HEAD) of /integrity, /trust, /security, /methodology
+//     /ai-policy on each candidate's homepage
+//
+// Output:
+//   E:/Temp/integrity-prospects/report.md    (ranked, human-triagable)
+//   E:/Temp/integrity-prospects/report.json  (structured, for follow-up)
+//
+// Tiering:
+//   T1 — Already publishes a trust file (INTEGRITY.md / TRUST.md / etc.).
+//        Half a day from Bronze. Highest-conversion outreach target.
+//   T2 — Has /trust or /methodology or /security page on their site.
+//        Cares about credibility; the framework is one more step in the
+//        same direction.
+//   T3 — Recent AI-product launch from HN, no trust artifacts found.
+//        Segment fit but cold.
+//
+// Usage:
+//   node dev-tools/prospect-listings.mjs
+//
+// Requires: `gh auth status` healthy. Skips GitHub stage if not.
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+const OUT_DIR = 'E:/Temp/integrity-prospects';
+const STARTVEST_REPOS = new Set([
+  'Startvest-LLC/theintegrityframework',
+  'Startvest-LLC/claritylift',
+  'Startvest-LLC/FieldLedger',
+  'Startvest-LLC/adacompliancedocs',
+  'Startvest-LLC/idealift',
+  'tjpinder/claritylift',
+  'tjpinder/FieldLedger',
+  'tjpinder/adacompliancedocs',
+  'tjpinder/IdeaLogger',
+]);
+
+// Only files with high signal-to-noise. Dropped AI-POLICY.md (mostly "this
+// repo rejects AI-generated PRs", not a product trust signal) and
+// RESPONSIBLE-AI.md (mostly Microsoft / training material).
+const GH_FILES = ['INTEGRITY.md', 'TRUST.md'];
+
+// Repo-level noise filter for T1. A repo with one of these substrings in
+// name or description is almost never a product seeking buyer trust signal.
+const REPO_NOISE_SUBSTRINGS = [
+  'docs', 'documentation', 'learning', 'training', 'awesome',
+  'tutorial', 'course', 'exam', 'prep', 'book', 'blog',
+  'wiki', 'srd', 'cookbook', 'cheatsheet', 'roadmap', 'curriculum',
+  'sample', 'samples', 'examples', 'demo', 'playground',
+  'translation', 'pathfinder', 'bible', 'haiku',
+  'azure-docs', 'microsoft-docs', 'microsoftdocs',
+  'blockchain', 'cryptocurrency', 'crypto-', 'bitcoin', 'ethereum',
+  'protocol', 'decentralized', 'ledger',
+  'university', 'academic', 'escience', 'github pages',
+  'mirror', 'fork of', 'archived',
+  'dictionary', 'vocabulary', 'words', 'language',
+  'show notes', 'podcast',
+];
+
+// Aggregator / repository hosts that look SPA-like to the probe. Exclude as
+// homepage values — they generate false trust-page hits.
+const HOMEPAGE_EXCLUDED_HOSTS = new Set([
+  'github.com', 'www.github.com',
+  'gitlab.com', 'www.gitlab.com',
+  'news.ycombinator.com',
+  'old.reddit.com', 'reddit.com', 'www.reddit.com',
+  'medium.com',
+  'docs.google.com',
+  'youtube.com', 'www.youtube.com',
+  'walmart.com', 'www.walmart.com',
+  'vercel.app',
+]);
+
+function homepageHost(url) {
+  try { return new URL(url).host.toLowerCase(); } catch { return null; }
+}
+
+function isExcludedHomepage(url) {
+  const host = homepageHost(url);
+  if (!host) return true;
+  if (HOMEPAGE_EXCLUDED_HOSTS.has(host)) return true;
+  // Anything ending in github.io / vercel.app is almost always a project
+  // landing page rather than a product site. Allow if subdomain explicitly
+  // looks productish — for now, exclude conservatively.
+  if (host.endsWith('.vercel.app')) return true;
+  return false;
+}
+const PROBE_PATHS = ['/integrity', '/trust', '/security', '/methodology', '/ai-policy'];
+
+// HN searches — each becomes a separate Algolia call.
+// Looking for AI-tool launches from the last 9 months.
+const HN_QUERIES = [
+  'Show HN AI',
+  'Show HN AI tool',
+  'Launch HN AI',
+  'Show HN compliance',
+  'Show HN trust',
+];
+const HN_SINCE_DAYS = 270;
+
+function ghApi(path) {
+  // gh api with per-page=100 already; caller passes a fully-formed path.
+  // execFileSync throws on non-zero exit; we let it propagate so the script
+  // dies fast on auth failures rather than silently producing empty results.
+  const out = execFileSync('gh', ['api', path, '-H', 'Accept: application/vnd.github+json'], {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+function ghSearchCodeByFilename(filename) {
+  // Code search API: filename qualifier matches files by exact name.
+  // Max 100 per page; we only take the first 100 to stay within rate limits.
+  const q = `filename:${filename}`;
+  try {
+    const data = ghApi(`/search/code?q=${encodeURIComponent(q)}&per_page=100`);
+    const items = data?.items ?? [];
+    return items.map((it) => ({
+      filename,
+      repo: it.repository?.full_name,
+      repoUrl: it.repository?.html_url,
+      repoDescription: it.repository?.description ?? '',
+      fileUrl: it.html_url,
+      pushedAt: it.repository?.pushed_at,
+      stars: it.repository?.stargazers_count ?? 0,
+    }));
+  } catch (err) {
+    console.error(`[gh] search filename=${filename} failed: ${err.message.slice(0, 200)}`);
+    return [];
+  }
+}
+
+function ghRepo(fullName) {
+  try {
+    return ghApi(`/repos/${fullName}`);
+  } catch {
+    return null;
+  }
+}
+
+async function hnAlgolia(query) {
+  const sinceTs = Math.floor(Date.now() / 1000) - HN_SINCE_DAYS * 86400;
+  const url =
+    `https://hn.algolia.com/api/v1/search?` +
+    `query=${encodeURIComponent(query)}` +
+    `&tags=story` +
+    `&hitsPerPage=50` +
+    `&numericFilters=created_at_i>${sinceTs}`;
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': 'integrity-prospector/0.1' } });
+    if (!res.ok) {
+      console.error(`[hn] ${query}: HTTP ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return (data.hits ?? [])
+      .filter((h) => h.url && h.title)
+      .map((h) => ({
+        title: h.title,
+        url: h.url,
+        author: h.author,
+        points: h.points ?? 0,
+        comments: h.num_comments ?? 0,
+        createdAt: h.created_at,
+        objectID: h.objectID,
+        hnUrl: `https://news.ycombinator.com/item?id=${h.objectID}`,
+        query,
+      }));
+  } catch (err) {
+    console.error(`[hn] ${query} threw: ${err.message}`);
+    return [];
+  }
+}
+
+function originOf(urlString) {
+  try {
+    const u = new URL(urlString);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return null;
+  }
+}
+
+async function probeContent(url, timeoutMs = 8000) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: ctrl.signal,
+      headers: {
+        'User-Agent': 'integrity-prospector/0.1 (outreach research)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    });
+    if (!res.ok) return { ok: false, status: res.status, length: 0 };
+    const text = await res.text();
+    return { ok: true, status: res.status, length: text.length, finalUrl: res.url };
+  } catch (err) {
+    return { ok: false, status: 0, length: 0, error: err.name === 'AbortError' ? 'timeout' : err.message };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Probe with SPA-fallback detection. Many marketing SaaS sites are SPAs that
+// return 200 + the full app shell for any path; without filtering, they look
+// like they have every trust page on earth. We detect SPAs by probing a
+// random nonsense path: if the site returns 200 with a body length close to
+// the homepage, it's an SPA and we drop it.
+async function probeDomain(homepageUrl) {
+  const origin = originOf(homepageUrl);
+  if (!origin) return { origin: null, hits: [], reachable: false };
+
+  const root = await probeContent(origin);
+  if (!root.ok) {
+    return { origin, hits: [], reachable: false, error: root.error };
+  }
+
+  const junkPath = '/__nope_' + Math.random().toString(36).slice(2, 10) + '__';
+  const junk = await probeContent(`${origin}${junkPath}`);
+  // SPA signature: junk path returns 200, and length within 5% of root length.
+  const isSpa =
+    junk.ok &&
+    Math.abs(junk.length - root.length) / Math.max(root.length, 1) < 0.05;
+
+  if (isSpa) {
+    return { origin, hits: [], reachable: true, isSpa: true };
+  }
+
+  const hits = [];
+  for (const path of PROBE_PATHS) {
+    const r = await probeContent(`${origin}${path}`);
+    // A real page must (a) return 200, (b) differ in length from the
+    // 404 page (junk), and (c) differ in length from the homepage.
+    // Tolerance is generous (>200 bytes off junk, >500 off root) to
+    // accept page templates that share chrome.
+    if (r.ok && Math.abs(r.length - junk.length) > 200 && Math.abs(r.length - root.length) > 500) {
+      hits.push(path);
+    }
+    await new Promise((res) => setTimeout(res, 400));
+  }
+  return { origin, hits, reachable: true, isSpa: false };
+}
+
+function looksLikeNoiseRepo(p) {
+  const haystack = `${p.repo} ${p.repoDescription ?? ''}`.toLowerCase();
+  return REPO_NOISE_SUBSTRINGS.some((s) => haystack.includes(s));
+}
+
+function classify({ ghHits, probedHits }) {
+  if (ghHits && ghHits.length > 0) return 'T1';
+  // 4+ matches almost always means SPA fallback that beat the length-diff
+  // detector. Real products rarely have 4+ trust-named pages.
+  if (probedHits && probedHits.length > 0 && probedHits.length <= 3) return 'T2';
+  return 'T3';
+}
+
+function rankWithin(tier, p) {
+  // Within a tier, rank by signal density.
+  if (tier === 'T1') {
+    // Multiple trust files > one. Has homepage > no homepage.
+    return (p.ghHits?.length ?? 0) * 100 + (p.homepage ? 10 : 0) + (p.stars ?? 0) / 100;
+  }
+  if (tier === 'T2') {
+    return (p.probedHits?.length ?? 0) * 10 + (p.hn?.points ?? 0) / 50;
+  }
+  return p.hn?.points ?? 0;
+}
+
+function mdEscape(s) {
+  return String(s ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+}
+
+function buildReport(byTier, generatedAt) {
+  const lines = [];
+  lines.push(`# Integrity Framework — outreach prospects`);
+  lines.push('');
+  lines.push(`Generated: ${generatedAt}`);
+  lines.push('');
+  const totals = Object.fromEntries(Object.entries(byTier).map(([k, v]) => [k, v.length]));
+  lines.push(`Totals: T1 ${totals.T1 ?? 0} · T2 ${totals.T2 ?? 0} · T3 ${totals.T3 ?? 0}`);
+  lines.push('');
+  lines.push(`**T1** — already publishes a trust file. Half-day from Bronze. Top priority.  `);
+  lines.push(`**T2** — has /trust or /methodology or /security page. Cares about credibility.  `);
+  lines.push(`**T3** — recent AI-product launch, no trust artifacts found yet. Segment fit, cold.`);
+  lines.push('');
+
+  for (const tier of ['T1', 'T2', 'T3']) {
+    const rows = byTier[tier] ?? [];
+    if (rows.length === 0) continue;
+    lines.push(`## ${tier} — ${rows.length} prospect${rows.length === 1 ? '' : 's'}`);
+    lines.push('');
+    if (tier === 'T1') {
+      lines.push('| Repo | Files found | Stars | Pushed | Description |');
+      lines.push('|---|---|---:|---|---|');
+      for (const p of rows) {
+        const files = (p.ghHits ?? []).map((h) => h.filename).join(', ');
+        lines.push(
+          `| [${mdEscape(p.repo)}](${p.repoUrl}) | ${mdEscape(files)} | ${p.stars ?? 0} | ${p.pushedAt?.slice(0, 10) ?? ''} | ${mdEscape(p.repoDescription).slice(0, 90)} |`,
+        );
+      }
+    } else if (tier === 'T2') {
+      lines.push('| Title / Repo | Homepage | Trust pages | HN | Notes |');
+      lines.push('|---|---|---|---:|---|');
+      for (const p of rows) {
+        const probed = (p.probedHits ?? []).join(', ');
+        const homepage = p.homepage ?? '';
+        const hn = p.hn ? `[${p.hn.points}↑](${p.hn.hnUrl})` : '';
+        const title = p.repo ? `[${mdEscape(p.repo)}](${p.repoUrl})` : mdEscape(p.title ?? p.homepage ?? '');
+        lines.push(
+          `| ${title} | ${homepage ? `[link](${homepage})` : ''} | ${mdEscape(probed)} | ${hn} | ${mdEscape(p.notes ?? '')} |`,
+        );
+      }
+    } else {
+      lines.push('| Title | Homepage | HN | Author |');
+      lines.push('|---|---|---:|---|');
+      for (const p of rows) {
+        const hn = p.hn ? `[${p.hn.points}↑](${p.hn.hnUrl})` : '';
+        lines.push(
+          `| ${mdEscape(p.title ?? '')} | ${p.homepage ? `[link](${p.homepage})` : ''} | ${hn} | ${mdEscape(p.author ?? '')} |`,
+        );
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push('Outreach guidance:');
+  lines.push('');
+  lines.push('1. Start with T1. They already wrote a trust file; the conversation is "you\'re 80% there, here\'s the framework."');
+  lines.push('2. T2 next. Their site has a /trust or /methodology page — they self-selected on caring about credibility.');
+  lines.push('3. T3 only after T1+T2 are exhausted. Cold but in-segment.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const generatedAt = new Date().toISOString();
+  console.error(`[start] ${generatedAt}`);
+
+  // ---------- Stage 1: GitHub code search ----------
+  console.error('[gh] code search by filename');
+  const ghByRepo = new Map();
+  for (const filename of GH_FILES) {
+    const hits = ghSearchCodeByFilename(filename);
+    console.error(`  ${filename}: ${hits.length} file hits`);
+    for (const h of hits) {
+      if (!h.repo) continue;
+      if (STARTVEST_REPOS.has(h.repo)) continue;
+      const existing = ghByRepo.get(h.repo) ?? {
+        repo: h.repo,
+        repoUrl: h.repoUrl,
+        repoDescription: h.repoDescription,
+        stars: h.stars,
+        pushedAt: h.pushedAt,
+        ghHits: [],
+      };
+      existing.ghHits.push({ filename: h.filename, fileUrl: h.fileUrl });
+      ghByRepo.set(h.repo, existing);
+    }
+  }
+  console.error(`[gh] unique repos: ${ghByRepo.size}`);
+
+  // Resolve each repo's homepage URL via the repos API so we can probe.
+  for (const [name, p] of ghByRepo) {
+    const r = ghRepo(name);
+    if (r) {
+      p.homepage = r.homepage && /^https?:\/\//.test(r.homepage) ? r.homepage : null;
+      p.archived = r.archived;
+      p.fork = r.fork;
+      p.stars = r.stargazers_count ?? p.stars;
+      p.repoDescription = r.description ?? p.repoDescription;
+    }
+  }
+
+  // ---------- Stage 2: HN Algolia ----------
+  console.error('[hn] algolia search');
+  const hnByUrl = new Map();
+  for (const q of HN_QUERIES) {
+    const hits = await hnAlgolia(q);
+    console.error(`  "${q}": ${hits.length} hits`);
+    for (const h of hits) {
+      if (!h.url) continue;
+      const existing = hnByUrl.get(h.url);
+      if (!existing || h.points > existing.points) {
+        hnByUrl.set(h.url, h);
+      }
+    }
+  }
+  console.error(`[hn] unique URLs: ${hnByUrl.size}`);
+
+  // ---------- Stage 3: probe domains for trust pages ----------
+  console.error('[probe] checking trust paths on candidate origins');
+  const t1Prospects = [];
+  let dropped = 0;
+  for (const p of ghByRepo.values()) {
+    if (p.archived || p.fork) { dropped++; continue; }
+    if (looksLikeNoiseRepo(p)) { dropped++; continue; }
+    // Require either a homepage URL set OR meaningful star count.
+    if (!p.homepage && (p.stars ?? 0) < 30) { dropped++; continue; }
+    if (p.homepage) {
+      const probe = await probeDomain(p.homepage);
+      p.probedHits = probe.hits;
+      p.reachable = probe.reachable;
+      p.isSpa = probe.isSpa;
+    }
+    t1Prospects.push(p);
+  }
+  console.error(`[gh] T1 candidates after noise filter: ${t1Prospects.length} (dropped ${dropped})`);
+
+  const t2OrT3 = [];
+  let i = 0;
+  let skippedHomepage = 0;
+  for (const hn of hnByUrl.values()) {
+    i++;
+    if (i % 10 === 0) console.error(`  hn probe ${i}/${hnByUrl.size}`);
+    if (isExcludedHomepage(hn.url)) { skippedHomepage++; continue; }
+    const probe = await probeDomain(hn.url);
+    t2OrT3.push({
+      title: hn.title,
+      homepage: hn.url,
+      author: hn.author,
+      hn,
+      probedHits: probe.hits,
+      reachable: probe.reachable,
+      origin: probe.origin,
+    });
+  }
+  console.error(`[hn] kept ${t2OrT3.length} prospects (${skippedHomepage} excluded as aggregator homepages)`);
+
+  // ---------- Stage 4: classify + rank ----------
+  const byTier = { T1: [], T2: [], T3: [] };
+  for (const p of t1Prospects) {
+    const tier = classify({ ghHits: p.ghHits, probedHits: p.probedHits });
+    byTier[tier].push(p);
+  }
+  for (const p of t2OrT3) {
+    const tier = classify({ ghHits: null, probedHits: p.probedHits });
+    byTier[tier].push(p);
+  }
+  for (const tier of Object.keys(byTier)) {
+    byTier[tier].sort((a, b) => rankWithin(tier, b) - rankWithin(tier, a));
+  }
+
+  // ---------- Stage 5: write report ----------
+  const md = buildReport(byTier, generatedAt);
+  const mdPath = `${OUT_DIR}/report.md`;
+  const jsonPath = `${OUT_DIR}/report.json`;
+  writeFileSync(mdPath, md, 'utf8');
+  writeFileSync(jsonPath, JSON.stringify({ generatedAt, byTier }, null, 2), 'utf8');
+
+  console.error(`\n[done]`);
+  console.error(`  T1: ${byTier.T1.length}`);
+  console.error(`  T2: ${byTier.T2.length}`);
+  console.error(`  T3: ${byTier.T3.length}`);
+  console.error(`  → ${mdPath}`);
+  console.error(`  → ${jsonPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/how-to-write-an-integrity-md/page.tsx
+++ b/src/app/how-to-write-an-integrity-md/page.tsx
@@ -1,0 +1,409 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { site } from '@/lib/site';
+
+const PAGE_URL = `${site.url}/how-to-write-an-integrity-md`;
+
+export const metadata: Metadata = {
+  title: 'How to write an INTEGRITY.md (in half a day)',
+  description:
+    'A step-by-step guide for founders writing an INTEGRITY.md to qualify their product for the Bronze tier of the Integrity Framework Directory. Includes a copy-paste template, a worked example, and the six vetoes explained in plain language.',
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: 'How to write an INTEGRITY.md (in half a day)',
+    description:
+      'A step-by-step guide for founders writing an INTEGRITY.md. Copy-paste template, worked example, and the six vetoes in plain language.',
+    type: 'article',
+    url: PAGE_URL,
+    siteName: site.name,
+  },
+};
+
+const TEMPLATE = `# INTEGRITY.md — <Product Name>
+
+**Product:** <Product Name> (<product-url>)
+**Operator:** <Org or solo-founder name>
+**Framework version evaluated against:** 1.0
+**Self-evaluation tier:** Bronze
+**Last updated:** <YYYY-MM-DD>
+
+<One paragraph: what the product does, who it's for, and why a trust signal
+matters for buyers in your segment.>
+
+---
+
+## Layer 1 vetoes — self-mapping
+
+### Veto 1 — Artifact versus outcome
+
+**Pass / Disclosed conflict / Fail.** <Two to four sentences. Does the product
+sell the underlying outcome, or does it sell a certification artifact that
+buyers mistake for the outcome? If the latter, the product fails this veto.>
+
+### Veto 2 — Independence
+
+**Pass / Disclosed conflict / Fail.** <Who reviews the product's work? Is the
+reviewer paid by the verified entity? If structural independence isn't
+possible, name the conflict directly and describe how it's contained.>
+
+### Veto 3 — Verifiability
+
+**Pass.** <How can a buyer verify the claims the product makes? URL of a
+public artifact, a runnable check, a versioned methodology page — name the
+specific evidence a buyer can read or run.>
+
+### Veto 4 — AI accountability
+
+**Pass.** <Who owns the decisions the product's AI surfaces? If a human is in
+the loop, name the gate. If outputs are presented as authoritative, name the
+review process. "We use AI" is not an answer.>
+
+### Veto 5 — Pricing-rigor alignment
+
+**Pass.** <Is there any pricing pressure that would lower review rigor? Free
+tier with paid badge? Per-seat pricing that incentivizes inflating headcount?
+Name the pressure or its absence directly.>
+
+### Veto 6 — The TechCrunch test
+
+**Pass with named risk.** <What's the most likely critical headline 18 months
+out? Write it. Then write the defense. If you can't write a defense without
+hand-waving, this veto fails — go fix the underlying issue before listing.>
+
+---
+
+## Version
+
+0.1 — <YYYY-MM-DD> — Initial self-mapping.
+
+## Changelog
+
+### 0.1 — <YYYY-MM-DD>
+- Initial INTEGRITY.md created.
+`;
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const faqs: FaqItem[] = [
+  {
+    q: 'How long does writing an INTEGRITY.md actually take?',
+    a: 'Half a day for a thoughtful founder. Most of the time goes into Veto 6 (the TechCrunch test) — writing the most likely critical headline against your product is the part that catches founders off guard. The other five vetoes are mechanical once you have an honest answer to each.',
+  },
+  {
+    q: 'Where should I host my INTEGRITY.md?',
+    a: 'Either at the root of your public repo (github.com/your-org/your-repo/blob/main/INTEGRITY.md) or at a stable URL on your product website (e.g., yourproduct.com/integrity). Both are accepted. The directory verifies by reading the URL — what matters is that it is publicly accessible and stays accessible.',
+  },
+  {
+    q: 'What does "Pass with disclosed conflict" mean?',
+    a: 'Some vetoes have legitimate edge cases. The directory operator itself is also a listee — that is a real conflict of interest. Naming the conflict directly and describing how it is contained is acceptable. Hiding it is not. "Pass" means no conflict; "Pass with disclosed conflict" means the conflict exists and is named and contained; "Fail" means the conflict cannot be honestly contained.',
+  },
+  {
+    q: 'Do I need to write the INTEGRITY.md myself, or can AI write it?',
+    a: 'You write it. AI-generated INTEGRITY.md content presented as authoritative fails Veto 4 by definition. AI as a drafting aid is fine, but the final text must be yours and you must stand behind every claim in it. The directory rejects cosmetic mappings on review.',
+  },
+  {
+    q: 'What if one of the six vetoes does not apply to my product?',
+    a: 'Address it anyway. If a veto genuinely does not apply (e.g., your product has no AI component and Veto 4 is N/A), say so explicitly and explain why. "N/A — this product has no AI surface; the Layer 4 review gate is not applicable." A blank section gets rejected; an honest N/A with reasoning gets accepted.',
+  },
+  {
+    q: 'Can I claim Silver in my INTEGRITY.md, or does that come later?',
+    a: 'Claim the tier you actually qualify for. Bronze requires only the INTEGRITY.md. Silver requires the INTEGRITY.md plus one of: integrity-cli green against your public repo, or a public methodology page with a versioned changelog. If your product has the Silver credential, claim it; the directory will verify before publishing the badge.',
+  },
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((it) => ({
+    '@type': 'Question',
+    name: it.q,
+    acceptedAnswer: { '@type': 'Answer', text: it.a },
+  })),
+};
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to write an INTEGRITY.md',
+  description:
+    'Step-by-step instructions for founders writing an INTEGRITY.md to qualify their product for the Bronze tier of the Integrity Framework Directory.',
+  totalTime: 'PT4H',
+  inLanguage: 'en-US',
+  url: PAGE_URL,
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Read the framework',
+      text: 'Read the canonical Integrity Framework spec at claritylift.ai/framework/v1. Pay particular attention to the six Layer 1 vetoes — your INTEGRITY.md will address each one by name.',
+      url: `${PAGE_URL}#step-1`,
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Copy the template',
+      text: 'Copy the INTEGRITY.md template into a new file at the root of your repo or your product website. The template has six veto sections pre-filled with the questions you need to answer.',
+      url: `${PAGE_URL}#step-2`,
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Map each veto honestly',
+      text: 'Work through each veto in order. Pass, Disclosed conflict, or Fail. Name conflicts directly; cosmetic fills are rejected on review. Veto 6 (the TechCrunch test) is the one most founders find hardest — write the most likely critical headline against your product, then write the defense.',
+      url: `${PAGE_URL}#step-3`,
+    },
+    {
+      '@type': 'HowToStep',
+      position: 4,
+      name: 'Publish to a public URL',
+      text: 'Commit the INTEGRITY.md to your public repo or publish it at a stable URL on your product website. The directory verifies by reading that URL.',
+      url: `${PAGE_URL}#step-4`,
+    },
+    {
+      '@type': 'HowToStep',
+      position: 5,
+      name: 'Submit to the directory',
+      text: 'Submit the listing at theintegrityframework.org/submit/form. The Startvest team reads the INTEGRITY.md within 14 calendar days and approves, requests changes, or rejects with reasons.',
+      url: `${PAGE_URL}#step-5`,
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to write an INTEGRITY.md (in half a day)',
+  description:
+    'A step-by-step guide for founders writing an INTEGRITY.md to qualify their product for the Bronze tier of the Integrity Framework Directory.',
+  author: { '@type': 'Organization', name: 'Startvest LLC', url: 'https://startvest.ai' },
+  publisher: { '@type': 'Organization', name: 'Startvest LLC' },
+  inLanguage: 'en-US',
+  mainEntityOfPage: PAGE_URL,
+  url: PAGE_URL,
+};
+
+export default function HowToWriteAnIntegrityMdPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <article className="container-wide py-16 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
+            Founder guide
+          </p>
+
+          <h1>How to write an INTEGRITY.md (in half a day)</h1>
+
+          {/* Direct-answer paragraph: extractable as a single AI Overview / Perplexity citation block. */}
+          <p className="mt-6 text-lg text-surface-700 leading-relaxed">
+            An <strong>INTEGRITY.md</strong> is a public file at the root of your repo or product
+            website where you self-map your product against the six Layer 1 vetoes of the
+            Integrity Framework. The directory uses it to qualify your product for the Bronze tier.
+            A thoughtful founder takes about half a day. The hard part is not the writing; it is
+            being honest about the trade-offs the framework asks you to name.
+          </p>
+
+          <h2 className="mt-12" id="step-1">Step 1 — Read the framework first</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            The framework is short and forkable, published under CC BY 4.0 at{' '}
+            <a href="https://claritylift.ai/framework/v1" className="text-brand-700 underline">
+              claritylift.ai/framework/v1
+            </a>
+            . You only strictly need the six Layer 1 vetoes for an INTEGRITY.md, but read all three
+            layers — the deeper architectural and operational sections explain why the vetoes are
+            shaped the way they are.
+          </p>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Skim the directory&apos;s own{' '}
+            <a
+              href="https://github.com/Startvest-LLC/theintegrityframework/blob/master/INTEGRITY.md"
+              className="text-brand-700 underline"
+            >
+              INTEGRITY.md
+            </a>{' '}
+            on the way through. It is the gold-standard example: the directory is itself a product
+            evaluated against the framework, and it carries a real disclosed conflict of interest
+            (operator-as-listee) for Veto 2, which is a useful pattern to study before you write
+            yours.
+          </p>
+
+          <h2 className="mt-12" id="step-2">Step 2 — Copy the template</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Save this as <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">INTEGRITY.md</code>{' '}
+            at the root of your repo, or as a page at{' '}
+            <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">/integrity</code> on your
+            product website.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg bg-surface-900 p-4 text-xs leading-relaxed text-surface-50">
+            <code>{TEMPLATE}</code>
+          </pre>
+
+          <h2 className="mt-12" id="step-3">Step 3 — Work through the six vetoes</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Each veto asks one question. Answer in two to four sentences. Three legitimate verdicts:
+          </p>
+          <ul className="mt-3 list-disc pl-6 space-y-1 text-surface-700">
+            <li><strong>Pass</strong> — no conflict, no failure mode triggered.</li>
+            <li><strong>Pass with disclosed conflict</strong> — the conflict exists, is named directly, and is contained.</li>
+            <li><strong>Fail</strong> — fix the underlying issue before listing. The directory will not accept a Fail.</li>
+          </ul>
+
+          <h3 className="mt-8">Veto 1 — Artifact versus outcome</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>Does the product sell the underlying outcome, or a certification artifact buyers
+            mistake for the outcome?</em> Selling the badge is the failure mode. Selling the work
+            that produces the badge is the pass. Compliance products that ship a PDF and call it
+            done fail; ones that produce the underlying record and the PDF as a downstream artifact
+            pass.
+          </p>
+
+          <h3 className="mt-6">Veto 2 — Independence</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>Who reviews the product&apos;s work? Is the reviewer paid by the verified entity?</em>{' '}
+            If structural independence isn&apos;t possible, name the conflict directly and describe
+            how it is contained. The directory itself uses this pattern: Startvest is both operator
+            and listee, the conflict is named in every Startvest listing, and an external evaluator
+            is named as the long-term path. That is acceptable. Hiding it is not.
+          </p>
+
+          <h3 className="mt-6">Veto 3 — Verifiability</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>How can a buyer verify the product&apos;s claims without taking your word for it?</em>{' '}
+            Name a public artifact, a runnable check, or a versioned methodology page. &quot;Trust us&quot;
+            is the failure mode. A URL a buyer can read or a CLI they can run is the pass.
+          </p>
+
+          <h3 className="mt-6">Veto 4 — AI accountability</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>If your product surfaces AI output, who owns the decision?</em> Name the human
+            review gate, the audit log, or the explicit boundary where the AI output stops being
+            authoritative. Products that present AI output as final without a review gate fail.
+            Products with no AI surface can declare this veto N/A with one sentence of reasoning.
+          </p>
+
+          <h3 className="mt-6">Veto 5 — Pricing-rigor alignment</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>Does your pricing model create financial pressure to lower review rigor?</em>{' '}
+            Free-tier-with-paid-badge fails. Per-seat pricing that incentivizes inflating headcount
+            fails. Free-or-flat-rate-or-usage-based passes. Name the pressure honestly; if it
+            exists, name the structural protection that contains it.
+          </p>
+
+          <h3 className="mt-6">Veto 6 — The TechCrunch test</h3>
+          <p className="mt-2 text-surface-700 leading-relaxed">
+            <em>What is the most likely critical headline against your product 18 months out?</em>{' '}
+            Write the headline. Then write the defense. If you can&apos;t write a defense that
+            holds up without hand-waving, the veto fails — go fix the underlying issue before you
+            list. This is the veto most founders find hardest. It is also the one that catches the
+            real failure modes.
+          </p>
+
+          <h2 className="mt-12" id="step-4">Step 4 — Publish to a public URL</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Commit to your public repo, or publish at a stable URL on your product site. The
+            directory verifies the credential by reading the URL — what matters is that it is
+            public and that the URL stays valid.
+          </p>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            If you go the website route, give it a sensible permanent slug:{' '}
+            <code className="rounded bg-surface-100 px-1 py-0.5 text-sm">/integrity</code> is the
+            convention. The directory will use that URL on your listing.
+          </p>
+
+          <h2 className="mt-12" id="step-5">Step 5 — Submit to the directory</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Open the form at <Link href="/submit/form" className="text-brand-700 underline">/submit/form</Link>{' '}
+            and paste the URL. Review SLA is 14 calendar days from submission. You will get one of
+            three responses: approved with a publish date, changes requested with specific gaps, or
+            rejected with the reason.
+          </p>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            Prefer email or GitHub PR? Both paths still work — see the{' '}
+            <Link href="/submit" className="text-brand-700 underline">submit page</Link> for both.
+          </p>
+
+          <h2 className="mt-12">What gets rejected on review</h2>
+          <ul className="mt-4 list-disc pl-6 space-y-2 text-surface-700">
+            <li>
+              <strong>Cosmetic fills.</strong> A section that names the veto but doesn&apos;t answer
+              the question. Reviewers look for the substantive claim, not the heading.
+            </li>
+            <li>
+              <strong>Hand-waved Veto 6.</strong> A defense that requires the reader to assume good
+              faith on a non-trivial claim is not a defense. Re-write the headline harder; write
+              the defense against the harder version.
+            </li>
+            <li>
+              <strong>Hidden conflicts.</strong> Veto 2 fails if the conflict exists but is not
+              named. The directory&apos;s own INTEGRITY.md names the operator-as-listee conflict in
+              the second sentence of Veto 2; that is the bar.
+            </li>
+            <li>
+              <strong>AI-generated content presented as authoritative.</strong> AI as a drafting
+              aid is fine. AI-generated INTEGRITY.md text the founder hasn&apos;t internalized fails
+              Veto 4 by definition.
+            </li>
+            <li>
+              <strong>Self-attested Silver claims with no public credential URL.</strong>{' '}
+              Silver is verified, not declared. If you&apos;re claiming Silver, the
+              integrity-cli output URL or the methodology page URL must be public and reachable.
+            </li>
+          </ul>
+
+          <h2 className="mt-12">A worked example</h2>
+          <p className="mt-3 text-surface-700 leading-relaxed">
+            The cleanest worked example is the directory&apos;s own INTEGRITY.md — it deliberately
+            includes a real disclosed conflict (operator-as-listee under Veto 2) so founders can see
+            the &quot;Pass with disclosed conflict&quot; pattern applied honestly. Read it at{' '}
+            <a
+              href="https://github.com/Startvest-LLC/theintegrityframework/blob/master/INTEGRITY.md"
+              className="text-brand-700 underline"
+            >
+              github.com/Startvest-LLC/theintegrityframework/blob/master/INTEGRITY.md
+            </a>
+            . The four Startvest product INTEGRITY.md files (linked from each listing) are also
+            useful — they show four different products at different tiers handling the same vetoes
+            differently.
+          </p>
+
+          <h2 className="mt-12">Frequently asked questions</h2>
+          <dl className="mt-4 space-y-6">
+            {faqs.map((it) => (
+              <div key={it.q}>
+                <dt className="font-semibold text-surface-900">{it.q}</dt>
+                <dd className="mt-2 text-surface-700 leading-relaxed">{it.a}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="mt-12 flex flex-wrap gap-3">
+            <Link
+              href="/submit/form"
+              className="inline-flex items-center rounded-md bg-brand-700 px-5 py-3 text-sm font-medium text-white no-underline hover:bg-brand-800"
+            >
+              Submit your listing
+            </Link>
+            <Link
+              href="/what-is-the-integrity-framework"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              What is the framework?
+            </Link>
+            <Link
+              href="/listings"
+              className="inline-flex items-center rounded-md border border-surface-300 px-5 py-3 text-sm font-medium text-surface-800 no-underline hover:border-surface-400"
+            >
+              Browse listings
+            </Link>
+          </div>
+        </div>
+      </article>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -28,6 +28,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/implement-integrity-framework-90-days`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/integrity-md`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/how-to-vet-ai-tools`, lastModified, changeFrequency: 'monthly', priority: 0.85 },
+    { url: `${base}/how-to-write-an-integrity-md`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${base}/methodology`, lastModified, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${base}/changelog`, lastModified, changeFrequency: 'weekly', priority: 0.6 },
     { url: `${base}/submit`, lastModified, changeFrequency: 'monthly', priority: 0.6 },


### PR DESCRIPTION
## Summary

Two adoption artifacts that have been sitting untracked locally. Shipping the safe ones; surfacing the one that needs a privacy call.

### Included

1. **`/how-to-write-an-integrity-md`** ([page.tsx](src/app/how-to-write-an-integrity-md/page.tsx), 409 lines). Step-by-step half-day guide. Copy-paste template, worked example, six vetoes in plain language. Sitemap entry added at priority 0.9. **This is the URL every outreach email already points at** — until this ships, every \"half-day walkthrough\" link 404s.
2. **`dev-tools/prospect-listings.mjs`**. Discovery script: GitHub code search for `INTEGRITY.md` / `TRUST.md`, HN Algolia for recent AI launches, domain probes for `/trust` `/security` `/methodology`. Outputs a tiered T1/T2/T3 report to `E:/Temp/integrity-prospects/`. Pure tooling, no prospect names embedded.

### Intentionally **not** included — needs your call

**`dev-tools/outreach-templates.md`** (306 lines). Contains tier templates (A/B/C) + five fully worked examples naming specific prospects (`mnemom.ai`, `privacyforge.ai`, `saferate.com`, `basincheck.com`, `mvar-security/mvar`) + Tier B and Tier C tables naming ~16 more companies with judgment labels (\"Tier C — cold, compliance-shaped\"). Committing publicly exposes the outreach strategy to any of those founders who Google their own company name.

Three options:

| Option | Effort | Tradeoff |
|---|---|---|
| **A** — commit as-is publicly | 0 min | Fast. Named prospects can find judgment labels via Google. |
| **B** — commit a redacted version (drop worked examples, swap names for `<PROSPECT>`), keep originals local | ~20 min | Templates are usable; specific outreach context stays private. |
| **C** — gitignore it, back up to a private gist instead | 2 min | Keeps everything private; no version control in this repo. |

My recommendation: **B**. The templates themselves are valuable to commit (reusable across batches, peer review by anyone you bring on later); the named-prospect worked examples don't need to be public. Say the word and I'll do the redaction pass as a follow-up commit on this branch before you merge.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Visit `/how-to-write-an-integrity-md` after deploy — header, template, vetoes, FAQ render
- [ ] Verify sitemap entry: `curl https://theintegrityframework.org/sitemap.xml | grep how-to-write`
- [ ] `node dev-tools/prospect-listings.mjs` runs locally (requires `gh auth status` healthy)