### PR TITLE
ci: dogfood integrity-md-action on this repo

### DIFF
--- a/.github/integrity-badge.json
+++ b/.github/integrity-badge.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"integrity.md","message":"Silver","color":"c0c0c0"}

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -1,0 +1,47 @@
+name: integrity
+
+# Runs Startvest-LLC/integrity-md-action against the site's own INTEGRITY.md
+# on every PR + push to master. On push to master, commits an updated
+# shields.io endpoint JSON to .github/integrity-badge.json so the badge in
+# README.md stays in sync with the latest CLI verdict.
+#
+# The directory operator running its own gate on its own repo is part of the
+# credibility story — "we publish a framework and apply it to ourselves" is
+# Veto 2 self-mapping in CI form.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run integrity-md-action
+        id: integrity
+        uses: Startvest-LLC/integrity-md-action@v1
+        with:
+          path: .
+          badge-output: .github/integrity-badge.json
+
+      - name: Commit badge if changed
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          TIER: ${{ steps.integrity.outputs.tier }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/integrity-badge.json
+          if git diff --cached --quiet; then
+            echo "Badge unchanged ($TIER); nothing to commit."
+          else
+            git commit -m "chore(integrity): refresh badge ($TIER) [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # theintegrityframework.org
 
+[![integrity.md](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Startvest-LLC/theintegrityframework/master/.github/integrity-badge.json)](https://github.com/Startvest-LLC/theintegrityframework/actions/workflows/integrity.yml)
+
 The Integrity Framework Directory — a public directory of products evaluated against the Startvest Integrity Framework.
+
+The badge above is produced on every push to `master` by [`integrity-md-action`](https://github.com/Startvest-LLC/integrity-md-action) running against this repo's own [`INTEGRITY.md`](./INTEGRITY.md). Directory-operator-eats-its-own-dogfood, in CI form.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

Wires [`Startvest-LLC/integrity-md-action`](https://github.com/Startvest-LLC/integrity-md-action) into this repo so the directory operator's own gate runs on its own [`INTEGRITY.md`](./INTEGRITY.md) every push + PR. Real demonstration of the loop we just shipped, and a live badge on this repo's README that points outreach prospects at a working example.

## What this changes

- **`.github/workflows/integrity.yml`** — runs the action on PR + push-to-master + manual dispatch. On `master` pushes, writes `.github/integrity-badge.json` and auto-commits with `[skip ci]` so the bot commit doesn't loop.
- **`.github/integrity-badge.json`** — initial seed (Silver, matching local CLI verdict). CI overwrites on first master push if it disagrees.
- **`README.md`** — badge in the header, sourced via raw.githubusercontent.com → shields.io endpoint. One short paragraph explaining what it is.

## Tier expectation

Local `node bin/integrity.mjs check . --format=json` on `master` HEAD reports `tier: silver` (0 CRITICAL, 0 HIGH). CI may differ if filesystem case sensitivity flips `HIGH-SV-INTEGRITY-MD` (Linux is case-sensitive on `INTEGRITY.md`; this repo uses uppercase so should be fine). The PR run below will confirm.

## Test plan

- [ ] PR's integrity check passes (any tier ≠ `fail`)
- [ ] After merge, push-to-master triggers the workflow and `.github/integrity-badge.json` gets a commit if the tier changed
- [ ] Badge in README renders the current tier via shields.io
- [ ] `[skip ci]` in the bot commit prevents an infinite loop