### PR TITLE
feat(blog): scaffold /blog with MDX-as-route posts

### DIFF
--- a/src/app/blog/(posts)/layout.tsx
+++ b/src/app/blog/(posts)/layout.tsx
@@ -1,0 +1,21 @@
+// Post wrapper — applies to /blog/<slug> routes only, not the index.
+//
+// Route group `(posts)` doesn't appear in URLs; it lets us share a
+// layout across all posts (back-link + max-width + .blog-prose) without
+// affecting the /blog index, which keeps its own full-width container.
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+export default function PostLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="container-wide py-12 md:py-20">
+      <div className="mb-8 text-xs">
+        <Link href="/blog" className="text-brand-700 no-underline hover:text-brand-900">
+          ← Back to blog
+        </Link>
+      </div>
+      <div className="blog-prose">{children}</div>
+    </div>
+  );
+}

--- a/src/app/blog/blog-content.css
+++ b/src/app/blog/blog-content.css
@@ -1,0 +1,141 @@
+/* Blog content typography — scoped to the .blog-prose container that
+   individual post page.mdx files wrap their content in. Avoids needing
+   @tailwindcss/typography (which would require a new install, blocked
+   by the active Shai-Hulud moratorium).
+
+   The styles intentionally lean conservative; tune as posts ship. */
+
+.blog-prose {
+  max-width: 44rem;
+  color: rgb(51 65 85); /* surface-700 */
+  font-size: 1.0625rem;
+  line-height: 1.7;
+}
+
+.blog-prose h1 {
+  font-family: var(--font-display, ui-serif), Georgia, serif;
+  font-size: 2.25rem;
+  line-height: 1.15;
+  font-weight: 600;
+  color: rgb(15 23 42); /* surface-900 */
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.02em;
+}
+
+.blog-prose h2 {
+  font-family: var(--font-display, ui-serif), Georgia, serif;
+  font-size: 1.5rem;
+  line-height: 1.2;
+  font-weight: 600;
+  color: rgb(15 23 42);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.blog-prose h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: rgb(15 23 42);
+  margin-top: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.blog-prose p,
+.blog-prose ul,
+.blog-prose ol,
+.blog-prose blockquote {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+}
+
+.blog-prose a {
+  color: rgb(29 78 216); /* brand-700 */
+  text-decoration: none;
+}
+
+.blog-prose a:hover {
+  text-decoration: underline;
+}
+
+.blog-prose ul,
+.blog-prose ol {
+  padding-left: 1.5rem;
+}
+
+.blog-prose ul {
+  list-style: disc;
+}
+
+.blog-prose ol {
+  list-style: decimal;
+}
+
+.blog-prose li {
+  margin-bottom: 0.5rem;
+}
+
+.blog-prose blockquote {
+  border-left: 3px solid rgb(226 232 240); /* surface-200 */
+  padding-left: 1rem;
+  color: rgb(71 85 105); /* surface-600 */
+  font-style: italic;
+}
+
+.blog-prose code {
+  background-color: rgb(241 245 249); /* surface-100 */
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.9em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.blog-prose pre {
+  background-color: rgb(15 23 42); /* surface-900 */
+  color: rgb(226 232 240); /* surface-200 */
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.blog-prose pre code {
+  background-color: transparent;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+.blog-prose hr {
+  border: 0;
+  border-top: 1px solid rgb(226 232 240);
+  margin: 2.5rem 0;
+}
+
+.blog-prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+.blog-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  font-size: 0.95em;
+}
+
+.blog-prose th,
+.blog-prose td {
+  border-bottom: 1px solid rgb(226 232 240);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.blog-prose th {
+  font-weight: 600;
+  color: rgb(15 23 42);
+}

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,16 @@
+// /blog layout — global wrapper for the blog section.
+//
+// Imports the scoped blog-content.css so the .blog-prose class is
+// available to both the index and individual post pages. The actual
+// post wrapper (back-link + max-width prose container) lives in the
+// (posts)/ route group's layout so it doesn't affect the index.
+//
+// Route groups recap: `(posts)/foo/page.mdx` renders at `/blog/foo`,
+// not `/blog/(posts)/foo`. The parens form a layout-only grouping.
+
+import type { ReactNode } from 'react';
+import './blog-content.css';
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,114 @@
+// /blog — index of all blog posts.
+//
+// Posts live as MDX-as-route files at src/app/blog/<slug>/page.mdx. The
+// existing next.config.mjs already wires @next/mdx with remark-frontmatter +
+// remark-gfm + rehype-slug, so each post renders directly. This index page
+// walks the filesystem at request time, reads YAML frontmatter via
+// gray-matter, and emits a sorted list.
+//
+// Authoring flow:
+//   - scripts/aio-emit-blog-md.cjs (in marketing-agent) emits a skeleton
+//     page.mdx into src/app/blog/<slug>/page.mdx
+//   - fill in the body, PR, deploy
+//   - mark the AIO brief published: prapi aio publish <brief-id> <url>
+
+import type { Metadata } from 'next';
+import fs from 'node:fs';
+import path from 'node:path';
+import Link from 'next/link';
+import matter from 'gray-matter';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'Field reports on AI-tool integrity, framework adoption, and what we learn evaluating products in the directory.',
+  alternates: { canonical: '/blog' },
+};
+
+// Re-read posts on each request — new MDX files added via PR show up on the
+// next request without a deploy-time rebuild of this route. Cheap (just fs
+// + small gray-matter parses) compared to ISR caching wrinkles.
+export const dynamic = 'force-dynamic';
+
+interface PostSummary {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  category: string | null;
+}
+
+function loadPosts(): PostSummary[] {
+  const dir = path.join(process.cwd(), 'src', 'app', 'blog');
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  const posts: PostSummary[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const slug = entry.name;
+    const mdxPath = path.join(dir, slug, 'page.mdx');
+    if (!fs.existsSync(mdxPath)) continue;
+    const raw = fs.readFileSync(mdxPath, 'utf8');
+    const { data } = matter(raw);
+    if (typeof data?.title !== 'string') continue;
+    posts.push({
+      slug,
+      title: data.title,
+      description: typeof data.description === 'string' ? data.description : '',
+      publishedAt: typeof data.publishedAt === 'string' ? data.publishedAt : '',
+      category: typeof data.category === 'string' ? data.category : null,
+    });
+  }
+
+  posts.sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1));
+  return posts;
+}
+
+export default function BlogIndex() {
+  const posts = loadPosts();
+
+  return (
+    <section className="border-b border-surface-200">
+      <div className="container-wide py-16 md:py-24">
+        <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">Blog</p>
+        <h1 className="max-w-3xl">Field reports.</h1>
+        <p className="mt-6 max-w-2xl text-lg text-surface-600">
+          Notes from evaluating AI products against the Integrity Framework — what we&rsquo;re
+          seeing, what&rsquo;s shifting, and where the directory tier signals come from.
+        </p>
+
+        {posts.length === 0 ? (
+          <div className="mt-12 rounded-md border border-surface-200 bg-surface-50 p-6 text-sm text-surface-600">
+            No posts yet. New posts land as PRs that drop an MDX file at{' '}
+            <code>src/app/blog/&lt;slug&gt;/page.mdx</code>.
+          </div>
+        ) : (
+          <ul className="mt-12 space-y-8">
+            {posts.map((p) => (
+              <li key={p.slug} className="border-b border-surface-200 pb-8 last:border-b-0">
+                <Link href={`/blog/${p.slug}`} className="no-underline group block">
+                  <div className="flex items-baseline gap-3 text-xs text-surface-500 mb-2">
+                    {p.publishedAt && <time>{p.publishedAt}</time>}
+                    {p.category && (
+                      <>
+                        <span aria-hidden="true">·</span>
+                        <span>{p.category}</span>
+                      </>
+                    )}
+                  </div>
+                  <h2 className="text-2xl font-display font-semibold text-surface-900 group-hover:text-brand-700">
+                    {p.title}
+                  </h2>
+                  {p.description && (
+                    <p className="mt-2 max-w-2xl text-surface-600">{p.description}</p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -21,6 +21,9 @@ export function Nav() {
           <Link href="/methodology" className="text-surface-700 no-underline hover:text-brand-700">
             Methodology
           </Link>
+          <Link href="/blog" className="text-surface-700 no-underline hover:text-brand-700">
+            Blog
+          </Link>
           <Link href="/submit" className="text-surface-700 no-underline hover:text-brand-700">
             Submit
           </Link>


### PR DESCRIPTION
## Summary
First scaffolding pass for a TIF blog. Reuses TIF's existing MDX pipeline (\`@next/mdx\` + \`remark-frontmatter\` + \`remark-gfm\` + \`rehype-slug\` are already wired in \`next.config.mjs\`) so posts ship as \`src/app/blog/<slug>/page.mdx\` with no new dependencies.

## What's added
- \`src/app/blog/page.tsx\` — index. Walks the filesystem for \`src/app/blog/<slug>/page.mdx\`, parses YAML frontmatter via \`gray-matter\` (already a dep), lists posts sorted by \`publishedAt\`. Empty-state message documents the authoring path.
- \`src/app/blog/layout.tsx\` — global wrapper that imports the scoped \`blog-content.css\`.
- \`src/app/blog/(posts)/layout.tsx\` — route group layout. Applies the back-link + max-width + \`.blog-prose\` container to post pages ONLY (the index keeps its own full-width container).
- \`src/app/blog/blog-content.css\` — scoped typography for rendered MDX bodies. Avoids \`@tailwindcss/typography\` (not a dep; Shai-Hulud install moratorium would block adding it).
- \`src/components/Nav.tsx\` — adds "Blog" between Methodology and Submit.

## Authoring flow
\`\`\`
marketing-agent$ node scripts/aio-emit-blog-md.cjs <brief-id>
  → emits src/app/blog/<slug>/page.mdx (YAML frontmatter + MDX body)

theintegrityframework$ git pr open
  → deploy

prapi-cli$ prapi aio publish <brief-id> https://theintegrityframework.org/blog/<slug>
\`\`\`

## Why MDX-as-route over a dynamic \`[slug]\` reader
TIF's \`next.config.mjs\` already wires the MDX pipeline. Reusing it means:
- No new deps (avoids the install moratorium)
- Frontmatter stripping comes for free via \`remark-frontmatter\`
- The blog index reads frontmatter separately via \`fs\` + \`gray-matter\`

A dynamic \`[slug]\` route would need a markdown renderer (\`marked\`, \`remark-html\`, etc.) — none are deps yet.

## Companion work (separate PRs)
- \`marketing-agent\` PR (open after this): update \`scripts/aio-emit-blog-md.cjs\` to drop the \`needsBlogScaffold: true\` flag for TIF and point its \`contentDir\` at \`src/app/blog\` with \`<slug>/page.mdx\` path template.

## Test plan
- [x] \`tsc --noEmit\` clean against the scaffold
- [ ] \`bun run build\` (or \`next build\`) produces /blog as a route
- [ ] \`/blog\` renders empty-state copy with no posts present
- [ ] Drop a sample \`(posts)/hello/page.mdx\` → \`/blog\` lists it and \`/blog/hello\` renders with prose typography + back-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)