### PR TITLE
fix(listings): shorten VettedHaul description under 160-char limit

### DIFF
--- a/data/listings.json
+++ b/data/listings.json
@@ -116,7 +116,7 @@
     {
       "slug": "vettedhaul",
       "name": "VettedHaul",
-      "description": "Defensible carrier vetting and subpoena-ready audit trail for freight brokers. Captures FMCSA safety rating, CSA scores, insurance currency, and operating authority at the moment of booking. Built for the post-Montgomery v. Caribe Transport legal standard.",
+      "description": "Defensible carrier vetting and subpoena-ready audit trail for freight brokers. Built for the post-Montgomery v. Caribe Transport legal standard.",
       "homepageUrl": "https://vettedhaul.com",
       "integrityMdUrl": "https://vettedhaul.com/integrity",
       "tier": "bronze",


### PR DESCRIPTION
## Summary
The VettedHaul listing added in #33 had a 256-char \`description\` that broke the build (Zod schema enforces 160-char max at \`/listings/[slug]/opengraph-image\` page-data collection). Production deploy of #33 failed.

## Fix
Trim the description to 144 chars while keeping the Montgomery v. Caribe Transport anchor.

Before: 256 chars
After: 144 chars

## Verification
\`\`\`bash
node -e "const l = require('./data/listings.json'); const v = l.listings.find(x=>x.slug==='vettedhaul'); console.log(v.description.length)"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)