### PR TITLE
feat(seo): AEO rescue — DefinedTerm schemas + AI-bot robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://theintegrityframework.org/sitemap.xml

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 const CANONICAL_URL = '/framework/v1';
 const FRAMEWORK_VERSION = '1.0';
+const PAGE_URL = 'https://theintegrityframework.org/framework';
 
 export const metadata: Metadata = {
   title: 'The Integrity Framework',
@@ -11,9 +12,31 @@ export const metadata: Metadata = {
   alternates: { canonical: '/framework' },
 };
 
+// Standalone DefinedTerm JSON-LD. AI Overview citation hit-rate depends on
+// a top-level DefinedTerm (not just one nested inside Article.about), so we
+// emit this as its own ld+json block. Distribution report 2026-05-22 showed
+// "the integrity framework" collapsed from #1 → #17.
+const definedTermSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  '@id': `${PAGE_URL}#integrity-framework`,
+  name: 'The Integrity Framework',
+  alternateName: ['Integrity Framework', 'TIF'],
+  description:
+    'A published standard for product trustworthiness aimed at sub-enterprise AI tools, the segment where SOC 2 audits do not apply. Built around five recurring failure modes that destroyed prior compliance and trust-adjacent categories (trust-arbitrage failure, theater versus substance, conflict-of-interest, black-box AI, velocity-over-rigor) and organized as three operational layers, six pre-build vetoes, seven architectural constraints, and seven operational guardrails. Published under CC BY 4.0 and forkable.',
+  inDefinedTermSet: `https://theintegrityframework.org${CANONICAL_URL}`,
+  termCode: 'integrity-framework',
+  url: PAGE_URL,
+};
+
 export default function FrameworkPage() {
   return (
-    <article className="container-wide py-16 md:py-20">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSchema) }}
+      />
+      <article className="container-wide py-16 md:py-20">
       <header className="max-w-3xl">
         <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
           The Integrity Framework · v{FRAMEWORK_VERSION}
@@ -142,6 +165,7 @@ export default function FrameworkPage() {
           for that self-mapping.
         </p>
       </section>
-    </article>
+      </article>
+    </>
   );
 }

--- a/src/app/framework/why/page.tsx
+++ b/src/app/framework/why/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 const VERSION = '1.0';
 const LAST_UPDATED = '2026-04-26';
+const PAGE_URL = 'https://theintegrityframework.org/framework/why';
 
 export const metadata: Metadata = {
   title: 'Why the framework looks like this',
@@ -14,14 +15,37 @@ export const metadata: Metadata = {
     title: 'Why the Integrity Framework looks like this',
     description:
       'The reasoning behind v1.0: failure modes, three layers, six vetoes, published openly. The engineering rationale.',
-    url: 'https://theintegrityframework.org/framework/why',
+    url: PAGE_URL,
     publishedTime: `${LAST_UPDATED}T00:00:00Z`,
   },
 };
 
+// DefinedTerm for "sub-enterprise trust signal" — the keyword that collapsed
+// 23.2 positions (#1 → #24.2) in the 2026-05-22 distribution report. The
+// Integrity Framework is the sub-enterprise trust signal; this page is where
+// the reasoning behind that positioning lives, so the definition is anchored
+// here.
+const definedTermSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  '@id': `${PAGE_URL}#sub-enterprise-trust-signal`,
+  name: 'Sub-enterprise trust signal',
+  alternateName: ['Sub-enterprise AI trust', 'Trust signal for sub-enterprise AI tools'],
+  description:
+    'A sub-enterprise trust signal is a verifiable indicator of product trustworthiness designed for AI tools below the enterprise tier, where SOC 2 audits do not apply because the audit price exceeds the entire product budget. The Integrity Framework is the published sub-enterprise trust signal: founders self-map their product against six pre-build vetoes, post a public INTEGRITY.md, and a public directory at theintegrityframework.org lists them with a Bronze or Silver tier badge.',
+  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  termCode: 'sub-enterprise-trust-signal',
+  url: PAGE_URL,
+};
+
 export default function FrameworkWhyPage() {
   return (
-    <article className="container-wide py-16 md:py-24">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSchema) }}
+      />
+      <article className="container-wide py-16 md:py-24">
       <header className="max-w-3xl">
         <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
           Framework · reasoning · v{VERSION}
@@ -372,7 +396,8 @@ export default function FrameworkWhyPage() {
         </a>
         . CC BY 4.0. The only request is the version-and-changelog discipline.
       </p>
-    </article>
+      </article>
+    </>
   );
 }
 

--- a/src/app/integrity-md/page.tsx
+++ b/src/app/integrity-md/page.tsx
@@ -88,6 +88,21 @@ const articleSchema = {
   },
 };
 
+// Standalone DefinedTerm so AI Overviews citing "integrity framework spec"
+// can pull this block directly rather than reaching into Article.about.
+const definedTermSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  '@id': `${PAGE_URL}#integrity-md`,
+  name: 'INTEGRITY.md',
+  alternateName: ['Integrity Framework spec file', 'integrity.md'],
+  description:
+    'INTEGRITY.md is a public, founder-authored markdown file at the root of an AI product (in the repo or on the marketing site) that self-maps the product against The Integrity Framework v1.0. Bronze listings require all six Layer 1 vetoes self-mapped. Silver listings add the seven Layer 2 architectural constraints and seven Layer 3 operational guardrails. Published under CC BY 4.0.',
+  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  termCode: 'integrity-md',
+  url: PAGE_URL,
+};
+
 const TEMPLATE = `# INTEGRITY.md \u2014 <Product name>
 
 **Product:** <Product name> (<canonical-url>)
@@ -166,6 +181,7 @@ export default function IntegrityMdPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSchema) }} />
 
       <article className="container-wide py-16 md:py-20">
         <div className="max-w-3xl">

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -38,12 +38,33 @@ const articleSchema = {
   version: VERSION,
 };
 
+// Standalone DefinedTerm for "integrity framework methodology" — the keyword
+// that dropped 12.5 positions in the 2026-05-22 distribution report. The
+// Article schema alone doesn't surface "methodology" as a citable definition;
+// this block does.
+const definedTermSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  '@id': `${PAGE_URL}#methodology`,
+  name: 'Integrity Framework Directory methodology',
+  alternateName: ['Integrity Framework methodology', 'TIF directory methodology'],
+  description:
+    'The Integrity Framework Directory methodology is the published rubric used to evaluate listings on theintegrityframework.org. Bronze tier requires a public INTEGRITY.md self-mapping the six Layer 1 vetoes. Silver tier adds either an integrity-cli green run or a versioned methodology page. Every listing is re-scanned quarterly, on framework version bumps, and on triggered review. Delistings are published with a public note.',
+  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  termCode: 'directory-methodology',
+  url: PAGE_URL,
+};
+
 export default function MethodologyPage() {
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSchema) }}
       />
       <article className="container-wide py-16 md:py-20">
       <header className="max-w-3xl">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,31 @@
 import type { MetadataRoute } from 'next';
 import { site } from '@/lib/site';
 
+// AI bots that crawl the open web to populate Answer Engines.
+// Explicit allow rules make this site eligible for citation in
+// Google AI Overviews, Perplexity, ChatGPT search, and Claude search.
+// Distribution report 2026-05-22 showed brand terms collapsed
+// (the integrity framework #1 → #17, sub-enterprise trust signal
+// #1 → #24); naming each crawler so they treat the site as
+// open-for-citation rather than relying on the wildcard.
+const AI_BOTS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-Web',
+  'anthropic-ai',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Google-Extended',
+  'Applebot-Extended',
+  'CCBot',
+  'Bytespider',
+  'DuckAssistBot',
+  'cohere-ai',
+  'YouBot',
+];
+
 export default function robots(): MetadataRoute.Robots {
   const base = site.url.replace(/\/$/, '');
   return {
@@ -9,6 +34,10 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: '*',
         allow: '/',
       },
+      ...AI_BOTS.map((userAgent) => ({
+        userAgent,
+        allow: '/',
+      })),
     ],
     sitemap: `${base}/sitemap.xml`,
     host: base,

--- a/src/app/what-is-the-integrity-framework/page.tsx
+++ b/src/app/what-is-the-integrity-framework/page.tsx
@@ -87,11 +87,29 @@ const articleSchema = {
   },
 };
 
+// Standalone DefinedTerm. Article.about is sufficient for Article validity,
+// but AI Overviews extract top-level DefinedTerm blocks more reliably than
+// nested ones. Distribution report 2026-05-22 showed "the integrity framework"
+// collapsed from #1 → #17, so we duplicate the definition at the top level.
+const definedTermSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  '@id': `${PAGE_URL}#integrity-framework`,
+  name: 'The Integrity Framework',
+  alternateName: ['Integrity Framework', 'TIF'],
+  description:
+    'The Integrity Framework is a published standard for product trustworthiness aimed at sub-enterprise AI tools, the segment where SOC 2 audits do not apply. Founders self-map their product against six pre-build vetoes, post a public INTEGRITY.md, and the directory at theintegrityframework.org publishes them with a Bronze or Silver tier badge.',
+  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  termCode: 'integrity-framework',
+  url: PAGE_URL,
+};
+
 export default function WhatIsTheIntegrityFrameworkPage() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSchema) }} />
 
       <article className="container-wide py-16 md:py-20">
         <div className="max-w-3xl">


### PR DESCRIPTION
## Summary

Portfolio distribution report on **2026-05-22** showed The Integrity Framework had the worst brand-term collapse in the portfolio this week. AEO mention rate dropped **50% → 16%**.

| Keyword | Position |
|---|---|
| the integrity framework | #1 → #17.2 (-16.2) |
| sub-enterprise trust signal | #1 → #24.2 (-23.2) |
| theintegrityframework.org | #1.9 → #16.4 (-14.5) |
| integrity framework methodology | #4.9 → #17.4 (-12.5) |
| integrity framework spec | #1.9 → #12.4 (-10.5) |

Root cause is the same as the IdeaLift collapse this week (Startvest-LLC/idealift#2683): AI Overviews extract from top-level `DefinedTerm` blocks + explicit AI-bot allow rules, neither of which were emitted on this site for these terms.

## What changed

### `src/app/robots.ts` + removed `public/robots.txt`
Expanded the dynamic robots config to add explicit allow rules for: GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Bytespider, DuckAssistBot, cohere-ai, YouBot. Removed the static `public/robots.txt` so `robots.ts` is the single source of truth.

### Five pages get top-level `DefinedTerm` JSON-LD

| Page | Term | Why |
|---|---|---|
| `/framework` | The Integrity Framework | Canonical landing for the keyword that dropped 16.2 positions |
| `/framework/why` | Sub-enterprise trust signal | The worst-collapsed keyword (#1 → #24); this is where the reasoning lives |
| `/methodology` | Integrity Framework Directory methodology | Direct match for "integrity framework methodology" keyword |
| `/what-is-the-integrity-framework` | The Integrity Framework | Already had nested `Article.about` DefinedTerm; promoted to standalone block |
| `/integrity-md` | INTEGRITY.md | Already had nested `Article.about` DefinedTerm; promoted to standalone block |

AI Overviews extract top-level `DefinedTerm` blocks more reliably than nested ones. The Article schemas are unchanged on the two pages that already had nested forms — we duplicate at the top level rather than restructuring.

## Pattern (mirrors PR Startvest-LLC/idealift#2683)

Standalone `<script type="application/ld+json">` block per page emitting `@type: DefinedTerm` with `name`, `alternateName`, `description` (one-paragraph definition extractable as a single AI Overview citation), `inDefinedTermSet` pointing to `/framework/v1`, `termCode`, `url`, and `@id`.

## Why not also (out of scope here)

The IdeaLift rescue had 5 additional pieces — FAQ threshold lowering, `extractDefinitionLede()` helper, audit script, lede rewrites, autodraft enforcement. **None apply here**: `src/app/blog/(posts)/` is empty and there's no autodraft pipeline. Those pieces will be wired in when the blog corpus lands.

## Verification

- [x] `tsc --noEmit` clean
- [ ] Post-deploy: `curl https://theintegrityframework.org/robots.txt` shows AI-bot allow rules
- [ ] Post-deploy: view source on `/framework`, `/framework/why`, `/methodology` — confirm `"@type": "DefinedTerm"` JSON-LD
- [ ] Post-deploy: validate at least 3 pages in https://search.google.com/test/rich-results
- [ ] Post-deploy: submit `/sitemap.xml` re-crawl in GSC
- [ ] Next weekly distribution report: check brand-term position recovery deltas

## Test plan

- [ ] `curl https://theintegrityframework.org/robots.txt` returns dynamic content with AI-bot blocks
- [ ] Source view on `/framework` shows the DefinedTerm script tag
- [ ] No regression to existing FAQPage / Article schemas on `/what-is-the-integrity-framework` and `/integrity-md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)