### PR TITLE
fix(seo): rel='nofollow' on sister-brand outbound links (cliff fix)

### DIFF
--- a/src/app/listings/[slug]/page.tsx
+++ b/src/app/listings/[slug]/page.tsx
@@ -4,6 +4,33 @@ import { notFound } from 'next/navigation';
 import { TierBadge } from '@/components/TierBadge';
 import { getAllListingSlugs, getListingBySlug, getRescanHistory } from '@/lib/listings';
 
+// Sister Startvest-portfolio brands. Outbound links to these hosts on
+// programmatically-repeated directory pages get rel="nofollow" to avoid the
+// cross-network link-cluster pattern that triggered Google's link-spam
+// classifier on 2026-05-06 (see Startvest-LLC/idealift#2716).
+const SISTER_BRAND_HOSTS = new Set([
+  'idealift.app',
+  'claritylift.ai',
+  'fieldledger.us',
+  'hireposture.com',
+  'prapi.dev',
+  'vettedhaul.com',
+  'startvest.ai',
+  'adacompliancedocs.com',
+]);
+
+function relForOutbound(url: string | undefined): string {
+  const base = 'noreferrer noopener';
+  if (!url) return base;
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    if (SISTER_BRAND_HOSTS.has(host)) return `${base} nofollow`;
+  } catch {
+    // ignore unparseable URLs
+  }
+  return base;
+}
+
 export function generateStaticParams() {
   return getAllListingSlugs().map((slug) => ({ slug }));
 }
@@ -99,7 +126,11 @@ export default async function ListingDetailPage({
                 <div>
                   <dt className="text-surface-500">Homepage</dt>
                   <dd>
-                    <a href={listing.homepageUrl} target="_blank" rel="noreferrer noopener">
+                    <a
+                      href={listing.homepageUrl}
+                      target="_blank"
+                      rel={relForOutbound(listing.homepageUrl)}
+                    >
                       {listing.homepageUrl}
                     </a>
                   </dd>
@@ -107,7 +138,11 @@ export default async function ListingDetailPage({
                 <div>
                   <dt className="text-surface-500">INTEGRITY.md</dt>
                   <dd>
-                    <a href={listing.integrityMdUrl} target="_blank" rel="noreferrer noopener">
+                    <a
+                      href={listing.integrityMdUrl}
+                      target="_blank"
+                      rel={relForOutbound(listing.integrityMdUrl)}
+                    >
                       {listing.integrityMdUrl}
                     </a>
                   </dd>
@@ -122,7 +157,11 @@ export default async function ListingDetailPage({
                     </dt>
                     <dd>
                       {credentialLink && (
-                        <a href={credentialLink} target="_blank" rel="noreferrer noopener">
+                        <a
+                          href={credentialLink}
+                          target="_blank"
+                          rel={relForOutbound(credentialLink)}
+                        >
                           {credentialLink}
                         </a>
                       )}
@@ -188,7 +227,11 @@ export default async function ListingDetailPage({
               </div>
               <div className="mt-1">
                 {listing.operator.url ? (
-                  <a href={listing.operator.url} target="_blank" rel="noreferrer noopener">
+                  <a
+                    href={listing.operator.url}
+                    target="_blank"
+                    rel={relForOutbound(listing.operator.url)}
+                  >
                     {listing.operator.name}
                   </a>
                 ) : (


### PR DESCRIPTION
## Summary

Defensive mitigation for the cross-network link-cluster pattern that demoted `idealift.app` sitewide on 2026-05-06 (451 -> 39 GSC impressions overnight). Full investigation: `Startvest-LLC/idealift#2716`. Companion code fix on the IdeaLift side: `Startvest-LLC/idealift#2717`. This is 1 of 6 parallel sister-brand PRs implementing the cross-portfolio nofollow rollout.

## TIF-specific reasoning

The Integrity Framework is structurally different from the other portfolio sites — it is a standard + directory, not a product brand. Many of its outbound links to sister brands are the literal value of the page (directory listings, transparency self-grades, case studies). Per the user's caveat, those stay editorial.

But there is one place where sister-brand outbound links are **programmatically repeated across pages** and therefore look exactly like the cluster Google flagged: the `/listings/[slug]` directory detail page. Each listing detail renders 3-4 outbound links to the listed brand (homepage, INTEGRITY.md, silver credential, operator URL). Across the current 6 sister-brand listings that is ~24 same-day cross-domain links from `theintegrityframework.org` into the Startvest portfolio.

## What changed (1 file, 4 link sites)

- `src/app/listings/[slug]/page.tsx`
  - Added `SISTER_BRAND_HOSTS` allowlist + `relForOutbound()` helper at module scope
  - 4 `<a>` tags now resolve their `rel` via the helper: `homepageUrl`, `integrityMdUrl`, silver-credential link, `operator.url`
  - Result: outbound links to one of the 8 sister-brand hosts get `rel="noreferrer noopener nofollow"`. Non-portfolio listings still get full link equity (`noreferrer noopener`).

## What was intentionally left as editorial

- `src/app/framework/v1/page.tsx` — `productHref` for ClarityLift / FieldLedger / AdaComplianceDocs in the `SelfGradeRow` self-grading transparency table. One-page editorial transparency, not structurally repeated nav.
- `src/app/framework/cases/vettedhaul/page.tsx` — body-copy mentions of `vettedhaul.com/integrity` and `vettedhaul.com/methodology` inside the editorial case study.
- `src/app/how-to-write-an-integrity-md/page.tsx` — body-copy "read the framework at `claritylift.ai/framework/v1`" reference.
- `src/components/StructuredData.tsx` — `sameAs` URLs in JSON-LD. Not `<a>` hyperlinks, no PageRank flow.
- `src/components/Footer.tsx`, `src/components/Nav.tsx` — confirmed clean, no cross-brand nav links.
- `src/app/framework/audit-2026-q2/page.tsx` — already uses `rel="noopener nofollow"` on the audit data table.

## Counts

- Changed: **4 link sites** (in 1 component, multiplied across 6 prerendered listing pages = ~24 outbound links now nofollowed).
- Left as editorial: **6+ link sites** across 4 files.

## Verify

- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds (50/50 static pages, all 6 `/listings/[slug]` prerendered)
- [ ] `npm run lint` — pre-existing config issue (next lint + eslint v9), unrelated to this PR
- [ ] Spot-check rendered HTML on staging: `curl https://staging.theintegrityframework.org/listings/idealift | grep -E 'href="https://idealift'` should show `rel="noreferrer noopener nofollow"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)