### PR TITLE
feat(seo): publisher disclosure + parentOrganization schema

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -27,6 +27,11 @@ const definedTermSchema = {
   inDefinedTermSet: `https://theintegrityframework.org${CANONICAL_URL}`,
   termCode: 'integrity-framework',
   url: PAGE_URL,
+  publisher: {
+    '@type': 'Organization',
+    name: 'Startvest LLC',
+    url: 'https://startvest.ai',
+  },
 };
 
 export default function FrameworkPage() {

--- a/src/app/framework/why/page.tsx
+++ b/src/app/framework/why/page.tsx
@@ -36,6 +36,11 @@ const definedTermSchema = {
   inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
   termCode: 'sub-enterprise-trust-signal',
   url: PAGE_URL,
+  publisher: {
+    '@type': 'Organization',
+    name: 'Startvest LLC',
+    url: 'https://startvest.ai',
+  },
 };
 
 export default function FrameworkWhyPage() {

--- a/src/app/integrity-md/page.tsx
+++ b/src/app/integrity-md/page.tsx
@@ -101,6 +101,11 @@ const definedTermSchema = {
   inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
   termCode: 'integrity-md',
   url: PAGE_URL,
+  publisher: {
+    '@type': 'Organization',
+    name: 'Startvest LLC',
+    url: 'https://startvest.ai',
+  },
 };
 
 const TEMPLATE = `# INTEGRITY.md \u2014 <Product name>

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -53,6 +53,11 @@ const definedTermSchema = {
   inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
   termCode: 'directory-methodology',
   url: PAGE_URL,
+  publisher: {
+    '@type': 'Organization',
+    name: 'Startvest LLC',
+    url: 'https://startvest.ai',
+  },
 };
 
 export default function MethodologyPage() {

--- a/src/app/what-is-the-integrity-framework/page.tsx
+++ b/src/app/what-is-the-integrity-framework/page.tsx
@@ -102,6 +102,11 @@ const definedTermSchema = {
   inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
   termCode: 'integrity-framework',
   url: PAGE_URL,
+  publisher: {
+    '@type': 'Organization',
+    name: 'Startvest LLC',
+    url: 'https://startvest.ai',
+  },
 };
 
 export default function WhatIsTheIntegrityFrameworkPage() {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,7 +44,15 @@ export function Footer() {
         </div>
       </div>
       <div className="container-wide pb-8 text-xs text-surface-500">
-        Directory v{site.directoryVersion} · Framework v{site.frameworkVersion}
+        Directory v{site.directoryVersion} · Framework v{site.frameworkVersion} · Published by{' '}
+        <a
+          href="https://startvest.ai"
+          rel="nofollow"
+          className="text-surface-600 no-underline hover:text-brand-700"
+        >
+          {site.publisher}
+        </a>
+        .
       </div>
     </footer>
   );


### PR DESCRIPTION
## Why

Companion to PR #38 (`rel=\"nofollow\"` on sister-brand outbound links). That PR addressed the **acute** link-spam signal. This PR addresses the **structural** condition: explicitly disclose the corporate hierarchy so Google reads Startvest's portfolio as a legitimate holding-company structure, not a hidden PBN.

See `docs/seo-cliff-2026-05-06.md` in `Startvest-LLC/idealift` for full context.

## TIF-specific framing

TIF is structurally different from the product brands. It's a STANDARD **published by** Startvest LLC, not a Startvest-owned product brand. So the disclosure wording differs from the sister brands:

- Sister brands: "Part of the Startvest portfolio."
- TIF: "Published by Startvest LLC."

"Published by" is the accurate corporate hierarchy. "Part of the portfolio" would frame TIF as a product, which dilutes its position as an independent standard.

## Changes

### 1. Visible footer disclosure (`src/components/Footer.tsx`)

Added a disclosure line in the existing bottom row of the footer:

> Directory v0.2.1 · Framework v1.0 · Published by [Startvest LLC](https://startvest.ai).

Link uses `rel=\"nofollow\"` so the disclosure doesn't itself become a PBN signal. Minimal styling matches the existing version/framework line.

### 2. `publisher` Schema.org markup on framework-entity DefinedTerm schemas

Added `publisher: { Organization, Startvest LLC, startvest.ai }` to the five top-level standalone `DefinedTerm` schemas:

- `src/app/framework/page.tsx` — \"The Integrity Framework\" DefinedTerm
- `src/app/framework/why/page.tsx` — \"Sub-enterprise trust signal\" DefinedTerm
- `src/app/what-is-the-integrity-framework/page.tsx` — \"The Integrity Framework\" DefinedTerm
- `src/app/methodology/page.tsx` — \"Integrity Framework Directory methodology\" DefinedTerm
- `src/app/integrity-md/page.tsx` — \"INTEGRITY.md\" DefinedTerm

`publisher` is the correct schema property for a standard (vs `parentOrganization`, which describes an Organization). DefinedTerm.publisher tells Google: this term/standard is published by Startvest LLC.

### Decisions skipped (intentional)

- **Top-level Organization in `StructuredData.tsx`** already has `parentOrganization: Startvest LLC` — no change needed.
- **`framework/v1.json` route** already declares `publisher: Startvest LLC` and `creator: Startvest LLC` — no change needed.
- **Nested `author` / `publisher` Organization references on Article schemas** (in 13 page files) ARE Startvest LLC themselves. Adding `parentOrganization: Startvest LLC` to a Startvest LLC Organization block would be self-referential and semantically invalid. These already serve the disclosure goal by naming Startvest as the author/publisher.

## Verification

- `npm run typecheck` clean
- `npm run build` clean (all 30+ static routes generated successfully)
- `npm run lint` skipped — pre-existing eslint v9 config issue per PR #38

## Summary stats

- 6 files modified, 34 insertions, 1 deletion
- 5 framework-entity DefinedTerm schemas got `publisher` treatment
- 0 schemas got `parentOrganization` added (existing one in StructuredData.tsx already had it)
- 1 visible footer disclosure with `rel=\"nofollow\"` link