### PR TITLE
fix(seo): stable lastmod on sitemap — every URL was stamping new Date() per request

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,9 +2,23 @@ import type { MetadataRoute } from 'next';
 import { getActiveListings } from '@/lib/listings';
 import { site } from '@/lib/site';
 
+// Stable, content-meaningful lastmod for static URLs.
+//
+// Previously every URL used `lastModified: new Date()` evaluated per
+// request — Google sees every URL changing every fetch, ignores lastmod
+// as a freshness signal, and de-prioritizes the sitemap. Discovered
+// 2026-05-25 via URL Inspection sweep on the sister prapi.dev property
+// (110 of 118 URLs reported as "URL is unknown to Google" with the same
+// bug; GSC last successfully read the sitemap 19 days prior).
+//
+// Bump this constant when adding routes or doing real content edits.
+// Don't bump for cosmetic changes — false bumps rebuild the noise
+// reputation we just escaped.
+const CONTENT_LAST_UPDATED = new Date('2026-05-25T00:00:00Z');
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = site.url.replace(/\/$/, '');
-  const lastModified = new Date();
+  const lastModified = CONTENT_LAST_UPDATED;
 
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: `${base}/`, lastModified, changeFrequency: 'weekly', priority: 1.0 },


### PR DESCRIPTION
## Summary
Discovered via URL Inspection on the sister prapi.dev property: every entry in sitemap.ts used `lastModified: new Date()` evaluated per request. Google sees every URL changing every fetch, ignores lastmod as a freshness signal, and de-prioritizes the sitemap as a discovery source. On prapi.dev this surfaced as **110 of 118 sitemap URLs flagged "URL is unknown to Google"** despite the sitemap reporting "Success" in GSC — last successful read was 19 days prior.

## Fix
Replace per-request `new Date()` with a stable `CONTENT_LAST_UPDATED` constant. Per-item sources that already use real timestamps (blog post updatedAt, listing.lastRescannedDate, etc.) are preserved.

Bump `CONTENT_LAST_UPDATED` when adding routes or doing real content edits. Dont bump for cosmetic changes — false bumps rebuild the noise reputation we just escaped.

## Follow-up after deploy
In GSC → Sitemaps, **remove** the sitemap and **re-submit** it. Forces Google to re-fetch with the corrected lastmod values. Without that, Google may sit on its stale cached view indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)