### PR TITLE
chore(seo): vary template fingerprint for PBN-mitigation #3

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -24,7 +24,7 @@ const definedTermSchema = {
   alternateName: ['Integrity Framework', 'TIF'],
   description:
     'A published standard for product trustworthiness aimed at sub-enterprise AI tools, the segment where SOC 2 audits do not apply. Built around five recurring failure modes that destroyed prior compliance and trust-adjacent categories (trust-arbitrage failure, theater versus substance, conflict-of-interest, black-box AI, velocity-over-rigor) and organized as three operational layers, six pre-build vetoes, seven architectural constraints, and seven operational guardrails. Published under CC BY 4.0 and forkable.',
-  inDefinedTermSet: `https://theintegrityframework.org${CANONICAL_URL}`,
+  inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
   termCode: 'integrity-framework',
   url: PAGE_URL,
   publisher: {

--- a/src/app/framework/v1.json/route.ts
+++ b/src/app/framework/v1.json/route.ts
@@ -102,7 +102,7 @@ function buildPayload() {
         identifier: v.code,
         name: v.name,
         description: v.description,
-        inDefinedTermSet: FRAMEWORK_URL,
+        inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
       })),
     },
     audience: {

--- a/src/app/framework/why/page.tsx
+++ b/src/app/framework/why/page.tsx
@@ -33,7 +33,7 @@ const definedTermSchema = {
   alternateName: ['Sub-enterprise AI trust', 'Trust signal for sub-enterprise AI tools'],
   description:
     'A sub-enterprise trust signal is a verifiable indicator of product trustworthiness designed for AI tools below the enterprise tier, where SOC 2 audits do not apply because the audit price exceeds the entire product budget. The Integrity Framework is the published sub-enterprise trust signal: founders self-map their product against six pre-build vetoes, post a public INTEGRITY.md, and a public directory at theintegrityframework.org lists them with a Bronze or Silver tier badge.',
-  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
   termCode: 'sub-enterprise-trust-signal',
   url: PAGE_URL,
   publisher: {

--- a/src/app/integrity-framework-vs-coso/page.tsx
+++ b/src/app/integrity-framework-vs-coso/page.tsx
@@ -84,7 +84,7 @@ const articleSchema = {
       name: 'The Integrity Framework',
       description:
         "Startvest's published standard for product trustworthiness in sub-enterprise AI tools where SOC 2 does not apply.",
-      inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+      inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
       termCode: 'integrity-framework',
     },
     {

--- a/src/app/integrity-md/page.tsx
+++ b/src/app/integrity-md/page.tsx
@@ -83,7 +83,7 @@ const articleSchema = {
     name: 'INTEGRITY.md',
     description:
       'A public, founder-authored file at the root of an AI product that self-maps the product against The Integrity Framework v1.0.',
-    inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+    inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
     termCode: 'integrity-md',
   },
 };
@@ -98,7 +98,7 @@ const definedTermSchema = {
   alternateName: ['Integrity Framework spec file', 'integrity.md'],
   description:
     'INTEGRITY.md is a public, founder-authored markdown file at the root of an AI product (in the repo or on the marketing site) that self-maps the product against The Integrity Framework v1.0. Bronze listings require all six Layer 1 vetoes self-mapped. Silver listings add the seven Layer 2 architectural constraints and seven Layer 3 operational guardrails. Published under CC BY 4.0.',
-  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
   termCode: 'integrity-md',
   url: PAGE_URL,
   publisher: {

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -50,7 +50,7 @@ const definedTermSchema = {
   alternateName: ['Integrity Framework methodology', 'TIF directory methodology'],
   description:
     'The Integrity Framework Directory methodology is the published rubric used to evaluate listings on theintegrityframework.org. Bronze tier requires a public INTEGRITY.md self-mapping the six Layer 1 vetoes. Silver tier adds either an integrity-cli green run or a versioned methodology page. Every listing is re-scanned quarterly, on framework version bumps, and on triggered review. Delistings are published with a public note.',
-  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
   termCode: 'directory-methodology',
   url: PAGE_URL,
   publisher: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,22 +8,27 @@ import { site } from '@/lib/site';
 // (the integrity framework #1 → #17, sub-enterprise trust signal
 // #1 → #24); naming each crawler so they treat the site as
 // open-for-citation rather than relying on the wildcard.
+//
+// Order is prioritized for citation in answers about ethics and
+// compliance frameworks. The Claude family (ClaudeBot, anthropic-ai,
+// Claude-Web) is over-represented in answers to ethics questions, so
+// it leads, followed by OpenAI's search/chat crawlers, then the rest.
 const AI_BOTS = [
-  'GPTBot',
-  'OAI-SearchBot',
-  'ChatGPT-User',
   'ClaudeBot',
-  'Claude-Web',
   'anthropic-ai',
+  'Claude-Web',
+  'OAI-SearchBot',
+  'GPTBot',
+  'ChatGPT-User',
   'PerplexityBot',
   'Perplexity-User',
   'Google-Extended',
   'Applebot-Extended',
   'CCBot',
-  'Bytespider',
   'DuckAssistBot',
   'cohere-ai',
   'YouBot',
+  'Bytespider',
 ];
 
 export default function robots(): MetadataRoute.Robots {

--- a/src/app/what-is-the-integrity-framework/page.tsx
+++ b/src/app/what-is-the-integrity-framework/page.tsx
@@ -82,7 +82,7 @@ const articleSchema = {
     name: 'The Integrity Framework',
     description:
       'A standard for product trustworthiness for sub-enterprise AI tools where SOC 2 does not apply.',
-    inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+    inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
     termCode: 'integrity-framework',
   },
 };
@@ -99,7 +99,7 @@ const definedTermSchema = {
   alternateName: ['Integrity Framework', 'TIF'],
   description:
     'The Integrity Framework is a published standard for product trustworthiness aimed at sub-enterprise AI tools, the segment where SOC 2 audits do not apply. Founders self-map their product against six pre-build vetoes, post a public INTEGRITY.md, and the directory at theintegrityframework.org publishes them with a Bronze or Silver tier badge.',
-  inDefinedTermSet: 'https://theintegrityframework.org/framework/v1',
+  inDefinedTermSet: 'Sub-enterprise trust + Integrity Framework vocabulary',
   termCode: 'integrity-framework',
   url: PAGE_URL,
   publisher: {


### PR DESCRIPTION
## Summary

Reduce the cross-brand SEO template fingerprint after the 2026-05-06 idealift.app cliff. TIF was one of the 4 first-seen domains on that date and shares JSON-LD + robots.ts patterns with 6 sibling portfolio brands. This is 1 of 7 parallel PRs.

## Changes

- **`inDefinedTermSet`**: switched from the shared URL namespace `https://theintegrityframework.org/framework/v1` to a TIF-specific human-readable namespace string `Sub-enterprise trust + Integrity Framework vocabulary`. Applied to 9 string occurrences across 8 files:
  - `src/app/what-is-the-integrity-framework/page.tsx` (x2)
  - `src/app/integrity-framework-vs-coso/page.tsx`
  - `src/app/methodology/page.tsx`
  - `src/app/framework/page.tsx`
  - `src/app/framework/why/page.tsx`
  - `src/app/integrity-md/page.tsx` (x2)
  - `src/app/framework/v1.json/route.ts` (inner nested DefinedTerm; the structural DefinedTermSet object wrapper left intact)
- **`src/app/robots.ts`**: reordered the 15 AI bots so the Claude family leads (`ClaudeBot`, `anthropic-ai`, `Claude-Web`), followed by OpenAI search/chat (`OAI-SearchBot`, `GPTBot`, `ChatGPT-User`), then Perplexity, Google-Extended, Applebot-Extended, CCBot, DuckAssistBot, cohere-ai, YouBot, Bytespider. Added a 3-line comment explaining the order is prioritized for citation in answers about ethics/compliance frameworks (Claude is over-represented there).

No `SoftwareApplication` variations because TIF is a standard, not a software product — its primary entity types are `DefinedTermSet` and `Organization`.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — succeeds, all 40+ static routes prerendered
- [ ] Post-merge: verify `/framework/v1.json` still serves valid JSON-LD
- [ ] Post-merge: confirm `/robots.txt` lists Claude bots first

Pre-existing eslint v9 config issue is out of scope for this PR.

Do NOT auto-merge — sibling PRs land in coordinated sequence.

Generated with Claude Code