### PR TITLE
feat(seo): DefinedTerm + FAQPage schema for AI Overview citations

### DIFF
--- a/src/app/framework/v1/page.tsx
+++ b/src/app/framework/v1/page.tsx
@@ -56,12 +56,84 @@ const articleStructuredData = {
   license: 'https://creativecommons.org/licenses/by/4.0/',
 };
 
+// DefinedTerm + FAQPage so AI Overviews have a citable definition of the spec.
+// The page ranks for "integrity framework spec / methodology / v1" but only
+// emitted Article schema, so it was not being cited. Sourced from page content.
+const definedTermStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  name: 'The Integrity Framework v1.0',
+  description:
+    'The Integrity Framework v1.0 is a published standard for building compliance and trust-adjacent products under structural commitments. It defines three operational layers (pre-build vetoes, architectural constraints, operational guardrails), an eight-layer moat model, and a six-question vendor scorecard. Originated by Startvest LLC and published under CC BY 4.0.',
+  url: PAGE_URL,
+  inDefinedTermSet: {
+    '@type': 'DefinedTermSet',
+    name: 'Integrity Framework vocabulary',
+    url: PAGE_URL,
+  },
+};
+
+const faqStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is the Integrity Framework methodology?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'The Integrity Framework is a published standard for building compliance and trust-adjacent products under structural commitments. It defines three operational layers (pre-build vetoes, architectural constraints, operational guardrails), an eight-layer moat model, and a six-question vendor scorecard. It is reverse-engineered from the five recurring failure modes that have destroyed compliance categories before.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What are the three layers of the Integrity Framework?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Layer 1 is six pre-build vetoes evaluated before a product is built; a wrong answer kills the product. Layer 2 is seven architectural constraints baked into every product and CI-enforced where possible. Layer 3 is seven operational guardrails that keep the business model from turning sour over time.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is the Integrity Framework free to use?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. The framework is published under Creative Commons Attribution 4.0 (CC BY 4.0). You can copy, modify, and redistribute it, including for commercial use, provided you give credit and link to the original frozen version. There is no license fee. Adoption is the point.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How do I cite the Integrity Framework?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: `Cite the frozen version URL when the wording matters: ${PAGE_URL}. Cite the latest URL (theintegrityframework.org/framework) when the principle matters. In your product's INTEGRITY.md, link the frozen version you operate against and bump the link in your changelog when you upgrade.`,
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the Integrity Framework vendor scorecard?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'The vendor scorecard is six yes/no questions used to score any compliance or trust-adjacent vendor: public methodology page, refund-on-failure clause in the standard MSA, annual independent third-party audit with public findings, per-product INTEGRITY.md in the public repo, structurally enforced AI output review gate, and public kill criteria with specific thresholds. One point per yes; a score below five is information.',
+      },
+    },
+  ],
+};
+
 export default function FrameworkV1Page() {
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleStructuredData) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermStructuredData) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqStructuredData) }}
       />
 
       <article className="bg-white">
@@ -737,6 +809,17 @@ export default function FrameworkV1Page() {
               to this URL on {RELOCATED_DATE}; v1.0 wording is unchanged.
             </li>
           </ul>
+        </Section>
+
+        <Section id="faq" title="Frequently asked questions">
+          <dl className="space-y-6">
+            {faqStructuredData.mainEntity.map((qa) => (
+              <div key={qa.name}>
+                <dt className="font-semibold text-surface-900">{qa.name}</dt>
+                <dd className="mt-2 text-surface-600">{qa.acceptedAnswer.text}</dd>
+              </div>
+            ))}
+          </dl>
         </Section>
 
         <section className="px-4 sm:px-6 lg:px-8 py-12 bg-surface-50 border-t border-surface-200">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,131 @@ import Link from 'next/link';
 import { TierBadge } from '@/components/TierBadge';
 import { getDirectoryMeta } from '@/lib/listings';
 
+const SITE = 'https://theintegrityframework.org';
+const TERM_SET = { '@type': 'DefinedTermSet', name: 'Integrity Framework vocabulary', url: `${SITE}/framework/v1` };
+
+// DefinedTerm blocks so AI Overviews have a Wikipedia-style definition to cite
+// for "integrity framework", "bronze/silver/gold tier", etc. The site ranks #1
+// for these terms but was not being cited because no DefinedTerm/FAQPage schema
+// existed. Descriptions are sourced verbatim-in-spirit from the page content.
+const definedTerms = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name: 'Integrity Framework',
+    description:
+      'The Integrity Framework is a published standard for product trustworthiness for sub-enterprise AI tools, where SOC 2 does not apply. Products are evaluated against it and listed in a public directory with a tier badge per listing.',
+    url: SITE,
+    inDefinedTermSet: TERM_SET,
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name: 'Integrity Framework Bronze tier',
+    description:
+      'Bronze is the entry tier of the Integrity Framework. It requires a public INTEGRITY.md at the repo or product website with all six Layer 1 vetoes self-mapped. About half a day of honest reflection for a thoughtful founder.',
+    url: `${SITE}/#tiers`,
+    inDefinedTermSet: TERM_SET,
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name: 'Integrity Framework Silver tier',
+    description:
+      'Silver is the Integrity Framework tier above Bronze. It requires everything in Bronze, plus one of: integrity-cli passing green against the public repo, or a public methodology page with a versioned changelog.',
+    url: `${SITE}/#tiers`,
+    inDefinedTermSet: TERM_SET,
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name: 'Integrity Framework Gold tier',
+    description:
+      'Gold is a deferred Integrity Framework tier, reserved for a future framework version. The directory does not currently award Gold and will not retrofit a tier no one at this segment can reach.',
+    url: `${SITE}/#tiers`,
+    inDefinedTermSet: TERM_SET,
+  },
+];
+
+const faqPage = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is the Integrity Framework?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'The Integrity Framework is a published standard for product trustworthiness, built for sub-enterprise AI tools where SOC 2 is the wrong shape. Products are evaluated against it and listed in a public directory with a tier badge. Buyers use it to vet AI tools; founders use it to demonstrate framework conformance for their segment.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the Bronze tier?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Bronze is the entry tier. It requires a public INTEGRITY.md at the repo or product website, with all six Layer 1 vetoes self-mapped. It takes about half a day of honest reflection for a thoughtful founder.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the Silver tier?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Silver is everything in Bronze plus one credential: either integrity-cli passing green against the public repo, or a public methodology page with a versioned changelog. The founder picks the credential that fits the product shape.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the difference between Bronze and Silver?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Bronze requires a self-mapped public INTEGRITY.md against the six Layer 1 vetoes. Silver requires Bronze plus a verifiable credential: integrity-cli green against the public repo, or a versioned, changelogged methodology page. Bronze is self-attestation; Silver adds machine- or methodology-level verification.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is there a Gold tier?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Not yet. Gold is deferred to a future framework version. The directory will not retrofit a tier no one at this segment can currently reach.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How much does an Integrity Framework listing cost?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Nothing. Listings are not paid placement. No founder pays to be listed. Submissions are reviewed manually, with a 14-day review SLA from submission to first response.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How do I upgrade from Bronze to Silver?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Add one Silver credential to your Bronze listing: get integrity-cli passing green against your public repo, or publish a methodology page with a versioned changelog. Then resubmit. Framework version bumps trigger re-verification.',
+      },
+    },
+  ],
+};
+
 export default function HomePage() {
   const meta = getDirectoryMeta();
 
   return (
     <>
+      {definedTerms.map((term, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(term) }}
+        />
+      ))}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
       <section className="border-b border-surface-200">
         <div className="container-wide py-20 md:py-28">
           <p className="text-xs font-semibold uppercase tracking-widest text-brand-600 mb-4">
@@ -38,7 +158,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="border-b border-surface-200 bg-surface-50">
+      <section id="tiers" className="border-b border-surface-200 bg-surface-50 scroll-mt-20">
         <div className="container-wide py-16 md:py-20">
           <h2>Two tiers</h2>
           <p className="mt-3 max-w-2xl text-surface-600">
@@ -95,6 +215,20 @@ export default function HomePage() {
             <li>Not a comparison site. Listings stand alone.</li>
             <li>Not a paid placement. No founder pays to be listed.</li>
           </ul>
+        </div>
+      </section>
+
+      <section id="faq" className="border-t border-surface-200 scroll-mt-20">
+        <div className="container-wide py-16 md:py-20">
+          <h2>Frequently asked questions</h2>
+          <dl className="mt-8 max-w-2xl space-y-8">
+            {faqPage.mainEntity.map((qa) => (
+              <div key={qa.name}>
+                <dt className="font-semibold text-surface-900">{qa.name}</dt>
+                <dd className="mt-2 text-surface-600">{qa.acceptedAnswer.text}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
       </section>
     </>


### PR DESCRIPTION
## Why
From the 2026-05-31 portfolio AEO gap review: theintegrityframework.org **ranks #1–#3 for ~21 keywords** (bronze/silver/gold tier, tier comparison, tier requirements, framework methodology/spec/v1) but **isn't cited in Google's AI Overview**. Cause: the homepage emitted only Organization/WebSite/DataCatalog and /framework/v1 only Article. There was **no DefinedTerm or FAQPage** for AI Overview to lift a definition from — and AI Overview cites whichever source most resembles a Wikipedia-style definition.

(The schema here was already plain `<script>`, so unlike the idealift fix this wasn't an SSR bug — the schema was simply missing.)

## Changes
**Homepage (`src/app/page.tsx`)** — the #1-ranked tier cluster:
- 4 `DefinedTerm`s: Integrity Framework + Bronze/Silver/Gold tier (Gold correctly marked deferred, per the page)
- A 7-question `FAQPage` mapping to the gap keywords: what is each tier, Bronze vs Silver (tier comparison), requirements, cost, how to upgrade
- Matching **visible** FAQ section + `#tiers` anchor

**`/framework/v1` (`src/app/framework/v1/page.tsx`)** — the spec hub:
- `DefinedTerm` for the spec + 5-question `FAQPage` (methodology, three layers, CC BY 4.0/free, how to cite, vendor scorecard) + visible FAQ

All copy is sourced from existing on-page content (no invented claims). Emitted as plain `<script>` matching the repo's `StructuredData` component.

## Verification
- `tsc --noEmit` clean
- `next build` passes (both routes prerender)

## After deploy
```
curl -s https://theintegrityframework.org/ | grep -o '"@type":"DefinedTerm"'
curl -s https://theintegrityframework.org/framework/v1 | grep -o '"@type":"FAQPage"'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)